### PR TITLE
GP-3721 Fix dispatcher frequency not being loaded

### DIFF
--- a/ang/sqlTaskManager.js
+++ b/ang/sqlTaskManager.js
@@ -17,9 +17,10 @@
     .module(moduleName)
     .controller("sqlTaskManagerCtrl", function($scope, $location) {
       $scope.ts = CRM.ts();
-      $scope.dispatcher_frequency = getCurrentDispatcherFrequency();
+      $scope.dispatcher_frequency = null;
       $scope.resourceBaseUrl = CRM.config.resourceBase;
       getAllTasks();
+      getCurrentDispatcherFrequency();
 
       $scope.sortableOptions = {
         handle: ".handle-drag",
@@ -170,40 +171,39 @@
           $scope.$apply();
         });
       }
-    });
 
-  function getCurrentDispatcherFrequency() {
-    var frequency = null;
-    CRM.api3("Job", "get", {
-      sequential: 1,
-      api_entity: "Sqltask",
-      api_action: "execute",
-      is_active: 1
-    }).done(function(result) {
-      var jobs = result.values;
-      if (jobs.length > 0) {
-        array.forEach(job => {
-          switch (job.run_frequency) {
-            case "Always":
-              frequency = "Always";
-              break;
-            case "Hourly":
-              if (frequency === null || frequency === "Daily") {
-                frequency = "Hourly";
+      function getCurrentDispatcherFrequency() {
+        CRM.api3("Job", "get", {
+          sequential: 1,
+          api_entity: "Sqltask",
+          api_action: "execute",
+          is_active: 1
+        }).done(function(result) {
+          var jobs = result.values;
+          if (jobs.length > 0) {
+            jobs.forEach(job => {
+              switch (job.run_frequency) {
+                case "Always":
+                  $scope.dispatcher_frequency = "Always";
+                  break;
+                case "Hourly":
+                  if ($scope.dispatcher_frequency === null || $scope.dispatcher_frequency === "Daily") {
+                    $scope.dispatcher_frequency = "Hourly";
+                  }
+                  break;
+                case "Daily":
+                  if ($scope.dispatcher_frequency === null) {
+                    $scope.dispatcher_frequency = "Daily";
+                  }
+                  break;
+                default:
+                  console.log(`Unexpected run frequency: ${job.run_frequency}`);
+                  break;
               }
-              break;
-            case "Daily":
-              if (frequency === null) {
-                frequency = "Daily";
-              }
-              break;
-            default:
-              console.log(`Unexpected run frequency: ${job.run_frequency}`);
-              break;
+            });
+            $scope.$apply();
           }
         });
       }
     });
-    return frequency;
-  }
 })(angular, CRM.$, CRM._);

--- a/ang/sqlTaskManager/sqlTaskManager.html
+++ b/ang/sqlTaskManager/sqlTaskManager.html
@@ -31,7 +31,7 @@
                     the maximum frequency these taks are being executed with.')}}
     </div>
     <div ng-switch-when="Always">
-        {{ts('he dispatcher (and therefore all active tasks) will be triggered')}}
+        {{ts('The dispatcher (and therefore all active tasks) will be triggered')}}
         <strong>{{ts('with
                         every cron-run')}}</strong>. {{ts('Ask your administrator how often that is, in order to know the effective
                     maximum


### PR DESCRIPTION
This fixes an issue where the dispatcher frequency is not getting loaded. This is due to two issues:
- `getCurrentDispatcherFrequency()` performs an asynchronous API call but attempts to return the frequency immediately
- An undefined variable is being used in `getCurrentDispatcherFrequency()`