### PR TITLE
Fix log tables not being synced after adding input_required col

### DIFF
--- a/CRM/Sqltasks/Upgrader.php
+++ b/CRM/Sqltasks/Upgrader.php
@@ -193,6 +193,9 @@ class CRM_Sqltasks_Upgrader extends CRM_Sqltasks_Upgrader_Base {
     $column_exists = CRM_Core_DAO::singleValueQuery("SHOW COLUMNS FROM `civicrm_sqltasks` LIKE 'input_required';");
     if (!$column_exists) {
       CRM_Core_DAO::executeQuery("ALTER TABLE `civicrm_sqltasks` ADD COLUMN `input_required` tinyint COMMENT 'should this task require user input?';");
+      // update rebuild log tables
+      $logging = new CRM_Logging_Schema();
+      $logging->fixSchemaDifferences();
     }
   }
 


### PR DESCRIPTION
This fixes an issue where log tables were not synced after the `input_required` column was added.