### PR TITLE
GP-8038 Fix UI not setting task config version to 2

### DIFF
--- a/CRM/Sqltasks/Config/Format.php
+++ b/CRM/Sqltasks/Config/Format.php
@@ -24,10 +24,6 @@ class CRM_Sqltasks_Config_Format {
       return 1;
     }
 
-    if (!is_int($config['version'])) {
-      throw new Exception( 'Invalid task configuration version: ' . $config['version']);
-    }
-
     return $config['version'];
   }
 

--- a/ang/sqlTaskConfigurator.js
+++ b/ang/sqlTaskConfigurator.js
@@ -58,7 +58,8 @@
         scheduled_weekday: "1",
         scheduled_day: "1",
         scheduled_hour: "0",
-        scheduled_minute: "0"
+        scheduled_minute: "0",
+        version: 2
       };
       $scope.isExecutionBlockLoaded = function () {
         return loaderService.isExecutionBlockLoaded();
@@ -132,7 +133,6 @@
             var task = Object.assign({}, result.values);
             $scope.config = Object.assign({}, task.config);
             delete task["config"];
-            delete $scope.config.version;
             $scope.taskOptions = task;
 
             if ($scope.taskOptions.run_permissions === '') {


### PR DESCRIPTION
This fixes an issue where the UI doesn't set the task config version to "2", leading to various issues especially in the export functionality, including missing actions.