### PR TITLE
GP-8038 Add back missing .hlp templates

### DIFF
--- a/templates/CRM/Sqltasks/Action/APICall.hlp
+++ b/templates/CRM/Sqltasks/Action/APICall.hlp
@@ -1,0 +1,39 @@
+{*-------------------------------------------------------+
+| SYSTOPIA SQL TASKS EXTENSION                           |
+| Copyright (C) 2017 SYSTOPIA                            |
+| Author: B. Endres (endres@systopia.de)                 |
++--------------------------------------------------------+
+| This program is released as free software under the    |
+| Affero GPL license. You can redistribute it and/or     |
+| modify it under the terms of this license which you    |
+| can read by viewing the included agpl.txt or online    |
+| at www.gnu.org/licenses/agpl.html. Removal of this     |
+| copyright header is strictly prohibited without        |
+| written permission from the original author(s).        |
++-------------------------------------------------------*}
+
+{capture assign=apiurl}{crmURL p="civicrm/api"}{/capture}
+
+{htxt id='id-api-data'}
+  <p>{ts domain="de.systopia.sqltasks"}This table is the data source for you API calls.{/ts}</p>
+  <p>{ts domain="de.systopia.sqltasks"}This action will call the CiviCRM API3 for <strong><i>every</i></strong> row in this table.{/ts}</p>
+{/htxt}
+
+{htxt id='id-api-entity'}
+  <p>{ts domain="de.systopia.sqltasks"}Select the <strong>entity</strong> for you API3 call.{/ts}</p>
+  <p>{ts domain="de.systopia.sqltasks" 1=$apiurl}If you don't know what this means you might want to have a look at the <a href="%1" target="_blank">API Explorer</a>.{/ts}</p>
+{/htxt}
+
+{htxt id='id-api-action'}
+  <p>{ts domain="de.systopia.sqltasks"}Select the <strong>action</strong> for you API3 call.{/ts}</p>
+  <p>{ts domain="de.systopia.sqltasks" 1=$apiurl}If you don't know what this means you might want to have a look at the <a href="%1" target="_blank">API Explorer</a>.{/ts}</p>
+{/htxt}
+
+{htxt id='id-api-parameters'}
+  <p>{ts domain="de.systopia.sqltasks"}Here you can define the parameters for you API3 call. Every line in this text field assigns one parameter with either a constant or a column value from the table specified above (or a mix){/ts}</p>
+  <p>{ts domain="de.systopia.sqltasks"}You can access the table data using tokens like this: <code>{literal}{column_name}{/literal}</code>{/ts}</p>
+  <p>{ts domain="de.systopia.sqltasks"}The format is very simple:{/ts}</p>
+  <p>{ts domain="de.systopia.sqltasks"}&nbsp;&nbsp;<code>[Parameter Name]=[Value]</code>, e.g.{/ts}</p>
+  <p>{ts domain="de.systopia.sqltasks"}&nbsp;&nbsp;<code>first_name={literal}{contact_first_name}{/literal}</code><br/>&nbsp;&nbsp;<code>contact_type=Individual</code>{/ts}</p>
+  <p>{ts domain="de.systopia.sqltasks"}Each line that doesn't follow this format will be ignored.{/ts}</p>
+{/htxt}

--- a/templates/CRM/Sqltasks/Action/CSVExport.hlp
+++ b/templates/CRM/Sqltasks/Action/CSVExport.hlp
@@ -1,0 +1,44 @@
+{*-------------------------------------------------------+
+| SYSTOPIA SQL TASKS EXTENSION                           |
+| Copyright (C) 2017 SYSTOPIA                            |
+| Author: B. Endres (endres@systopia.de)                 |
++--------------------------------------------------------+
+| This program is released as free software under the    |
+| Affero GPL license. You can redistribute it and/or     |
+| modify it under the terms of this license which you    |
+| can read by viewing the included agpl.txt or online    |
+| at www.gnu.org/licenses/agpl.html. Removal of this     |
+| copyright header is strictly prohibited without        |
+| written permission from the original author(s).        |
++-------------------------------------------------------*}
+
+{htxt id='id-csv-columns'}
+  <p>{ts domain="de.systopia.sqltasks"}Here you have to define the columns you want to see in your CSV file. Every line in this text field represents one column, which then is mapped to one column in the SQL table that is being exported.{/ts}</p>
+  <p>{ts domain="de.systopia.sqltasks"}The format is very simple:{/ts}</p>
+  <p>&nbsp;&nbsp;{ts domain="de.systopia.sqltasks"}<code>[CSV Column Name]=[SQL Column]</code>, e.g.{/ts}</p>
+  <p>&nbsp;&nbsp;{ts domain="de.systopia.sqltasks"}<code>My supernice contact ID=contact_id</code>{/ts}</p>
+  <p>{ts domain="de.systopia.sqltasks"}Each line that doesn't follow this format will be ignored.{/ts}</p>
+{/htxt}
+
+{htxt id='id-csv-email'}
+  <p>{ts domain="de.systopia.sqltasks"}You can specify a comma separated list of email addresses that the resulting file will be sent to.{/ts}</p>
+  <p>{ts domain="de.systopia.sqltasks"}<strong>Caution!</strong> The data will be sent unencrypted. Please do not use this option if the resulting files contains sensitive data.{/ts}</p>
+{/htxt}
+
+{htxt id='id-csv-downloadURL'}
+  <p>{ts domain="de.systopia.sqltasks"}Do not attach csv file in the email, include {literal}<code>{sqltasks.downloadURL}</code>{/literal} token in your template, and it will be replaced by an URL to click and download the file through CiviCRM authentication{/ts}</p>
+{/htxt}
+
+{htxt id='id-csv-filename'}
+  <p>{ts domain="de.systopia.sqltasks"}The file name of the resulting CSV file.{/ts}</p>
+  <p>{ts domain="de.systopia.sqltasks"}You can use the token {literal}<code>{xxx}</code>{/literal}, which will be replaced by a current date string. The format (i.e. the xxx) is defined <a href="https://secure.php.net/manual/en/function.date.php#refsect1-function.date-parameters">here</a>. An example would be <code>{literal}{Y-m-d}{/literal}</code>.{/ts}</p>
+{/htxt}
+
+{htxt id='id-csv-path'}
+  <p>{ts domain="de.systopia.sqltasks"}This defines the path about where the resulting file is stored. If you leave it empty, a default path will be used.{/ts}</p>
+{/htxt}
+
+{htxt id='id-csv-sftp'}
+  <p>{ts domain="de.systopia.sqltasks"}Define the target SFTP path to upload your file to. The format is <code>sftp://user:password@host/path</code>, e.g. <code>sftp://reports:123456@www.reports-server.de/civic-reports</code>{/ts}</p>
+  <p>{ts domain="de.systopia.sqltasks"}<strong>Caution!</strong> These credentials will be stored in the CiviCRM database unencrypted. Please don't use sensitive accounts for uploading files.{/ts}</p>
+{/htxt}

--- a/templates/CRM/Sqltasks/Action/CallTask.hlp
+++ b/templates/CRM/Sqltasks/Action/CallTask.hlp
@@ -1,0 +1,27 @@
+{*-------------------------------------------------------+
+| SYSTOPIA SQL TASKS EXTENSION                           |
+| Copyright (C) 2018 SYSTOPIA                            |
+| Author: B. Endres (endres@systopia.de)                 |
++--------------------------------------------------------+
+| This program is released as free software under the    |
+| Affero GPL license. You can redistribute it and/or     |
+| modify it under the terms of this license which you    |
+| can read by viewing the included agpl.txt or online    |
+| at www.gnu.org/licenses/agpl.html. Removal of this     |
+| copyright header is strictly prohibited without        |
+| written permission from the original author(s).        |
++-------------------------------------------------------*}
+
+{htxt id='id-task-tasks'}
+  <p>{ts domain="de.systopia.sqltasks"}You can select any tasks (except this one) to be run as an action of this task.{/ts}</p>
+  <p>{ts domain="de.systopia.sqltasks"}Only enabled tasks will be run, in the order defined by the task manager, <i>not</i> this list.{/ts}</p>
+  <p>{ts domain="de.systopia.sqltasks"}The tasks selected here will be run <i>together</i> with the ones selected by category below.{/ts}</p>
+  <p>{ts domain="de.systopia.sqltasks"}<strong>Be <id>very</id> careful with this! You can easily create circular execution patterns that <i>will</i> break the system.</strong>{/ts}</p>
+{/htxt}
+
+{htxt id='id-task-categories'}
+  <p>{ts domain="de.systopia.sqltasks"}You can select any number of task categories to be run as an action of this task.{/ts}</p>
+  <p>{ts domain="de.systopia.sqltasks"}Only enabled tasks of the selected categories will be run, in the order defined by the task manager, <i>not</i> this list.{/ts}</p>
+  <p>{ts domain="de.systopia.sqltasks"}The tasks selected here will be run <i>together</i> with the ones selected individually above.{/ts}</p>
+  <p>{ts domain="de.systopia.sqltasks"}<strong>Be <id>very</id> careful with this! You can easily create circular execution patterns that <i>will</i> break the system.</strong>{/ts}</p>
+{/htxt}

--- a/templates/CRM/Sqltasks/Action/CreateActivity.hlp
+++ b/templates/CRM/Sqltasks/Action/CreateActivity.hlp
@@ -1,0 +1,35 @@
+{*-------------------------------------------------------+
+| SYSTOPIA SQL TASKS EXTENSION                           |
+| Copyright (C) 2017 SYSTOPIA                            |
+| Author: B. Endres (endres@systopia.de)                 |
++--------------------------------------------------------+
+| This program is released as free software under the    |
+| Affero GPL license. You can redistribute it and/or     |
+| modify it under the terms of this license which you    |
+| can read by viewing the included agpl.txt or online    |
+| at www.gnu.org/licenses/agpl.html. Removal of this     |
+| copyright header is strictly prohibited without        |
+| written permission from the original author(s).        |
++-------------------------------------------------------*}
+
+{htxt id='id-activity-datetime'}
+  <p>{ts domain="de.systopia.sqltasks"}You can use any string as processed by PHP's <code>strtotime</code> function, see <a href="https://secure.php.net/manual/en/datetime.formats.php">HERE</a>.{/ts}</p>
+  <p>
+    {ts domain="de.systopia.sqltasks"}Examples:{/ts}
+    <ul>
+      <li>{ts domain="de.systopia.sqltasks"}<code>now</code>{/ts}</li>
+      <li>{ts domain="de.systopia.sqltasks"}<code>now + 2 days</code>{/ts}</li>
+      <li>{ts domain="de.systopia.sqltasks"}<code>tomorrow</code>{/ts}</li>
+    </ul>
+  </p>
+  <p>{ts domain="de.systopia.sqltasks"}The default is <code>now</code>.{/ts}</p>
+{/htxt}
+
+{htxt id='id-activity-tokens'}
+  <p>{ts domain="de.systopia.sqltasks"}When creating individual activities, you can use tokens of the form <code>{literal}{column_name}{/literal}</code>.{/ts}</p>
+  <p>{ts domain="de.systopia.sqltasks"}These tokens will be filled with data from the contact table, if <code>column_name</code> is set in the the contact table referenced above.{/ts}</p>
+{/htxt}
+
+{htxt id='id-activity-assignees'}
+  <p>{ts domain="de.systopia.sqltasks"}You can enter a comma-separated list of contact IDs to assign the activities to all of them.{/ts}</p>
+{/htxt}

--- a/templates/CRM/Sqltasks/Action/ResultHandler.hlp
+++ b/templates/CRM/Sqltasks/Action/ResultHandler.hlp
@@ -1,0 +1,35 @@
+{*-------------------------------------------------------+
+| SYSTOPIA SQL TASKS EXTENSION                           |
+| Copyright (C) 2017 SYSTOPIA                            |
+| Author: B. Endres (endres@systopia.de)                 |
++--------------------------------------------------------+
+| This program is released as free software under the    |
+| Affero GPL license. You can redistribute it and/or     |
+| modify it under the terms of this license which you    |
+| can read by viewing the included agpl.txt or online    |
+| at www.gnu.org/licenses/agpl.html. Removal of this     |
+| copyright header is strictly prohibited without        |
+| written permission from the original author(s).        |
++-------------------------------------------------------*}
+
+{htxt id='id-handler-email'}
+  <p>{ts domain="de.systopia.sqltasks"}Specify a comma separated list of email addresses that the resulting file will be sent to.{/ts}</p>
+{/htxt}
+
+{htxt id='id-handler-always'}
+  <p>{ts domain="de.systopia.sqltasks"}If you check this, the success handler will be always be executed unless there was an error. Otherwise it will only be sent if any of the tasks have actually "done something".{/ts}</p>
+{/htxt}
+
+{htxt id='id-handler-attach-log'}
+  <p>{ts domain="de.systopia.sqltasks"}Selecting this option will attach the log file of the execution to the email.{/ts}</p>
+{/htxt}
+
+{htxt id='id-handler-error-table'}
+  <p>{ts domain="de.systopia.sqltasks"}If you enter a table here, and it has a column called <code>error_message</code>, the listed errors will count as errors just as any other execution error.{/ts}</p>
+  <p>{ts domain="de.systopia.sqltasks"}You should make sure to use the same table for the success and error handler, otherwise there might be inconsistencies.{/ts}</p>
+  <p>{ts domain="de.systopia.sqltasks"}Since the success/error handlers will be executed <i>after</i> cleanup, the table used here can not be removed by the cleanup script. Use the <code>drop</code> option below.{/ts}</p>
+{/htxt}
+
+{htxt id='id-handler-error-table-drop'}
+  <p>{ts domain="de.systopia.sqltasks"}If you select this, the user error table (or view) will be dropped after this task finishes.{/ts}</p>
+{/htxt}

--- a/templates/CRM/Sqltasks/Action/RunSQL.hlp
+++ b/templates/CRM/Sqltasks/Action/RunSQL.hlp
@@ -1,0 +1,20 @@
+{*-------------------------------------------------------+
+| SYSTOPIA SQL TASKS EXTENSION                           |
+| Copyright (C) 2018 SYSTOPIA                            |
+| Author: B. Endres (endres@systopia.de)                 |
++--------------------------------------------------------+
+| This program is released as free software under the    |
+| Affero GPL license. You can redistribute it and/or     |
+| modify it under the terms of this license which you    |
+| can read by viewing the included agpl.txt or online    |
+| at www.gnu.org/licenses/agpl.html. Removal of this     |
+| copyright header is strictly prohibited without        |
+| written permission from the original author(s).        |
++-------------------------------------------------------*}
+
+{htxt id='id-sql-script'}
+  <p>{ts domain="de.systopia.sqltasks"}This is the SQL script. You can use it to create a helper table or view to drive subsequent actions. Of course you could also use this script to perform the required changes right in the database, but this is usually discouraged as it bypasses CiviCRM logic.{/ts}</p>
+  <p>{ts domain="de.systopia.sqltasksd"}You can paste and run <i>any</i> complete SQL script in here. <strong>But beware</strong>: with great power comes great responsibility!{/ts}</p>
+  <p>{ts domain="de.systopia.sqltasks"}{/ts}</p>
+  <p>{ts domain="de.systopia.sqltasks"}We recommend developing complex SQL scripts in an external editor, and simply copy/pasting it here.{/ts}</p>
+{/htxt}

--- a/templates/CRM/Sqltasks/Action/SegmentationAssign.hlp
+++ b/templates/CRM/Sqltasks/Action/SegmentationAssign.hlp
@@ -1,0 +1,52 @@
+{*-------------------------------------------------------+
+| SYSTOPIA SQL TASKS EXTENSION                           |
+| Copyright (C) 2017 SYSTOPIA                            |
+| Author: B. Endres (endres@systopia.de)                 |
++--------------------------------------------------------+
+| This program is released as free software under the    |
+| Affero GPL license. You can redistribute it and/or     |
+| modify it under the terms of this license which you    |
+| can read by viewing the included agpl.txt or online    |
+| at www.gnu.org/licenses/agpl.html. Removal of this     |
+| copyright header is strictly prohibited without        |
+| written permission from the original author(s).        |
++-------------------------------------------------------*}
+
+{htxt id='id-segmentation-assign-table'}
+  <p>{ts domain="de.systopia.sqltasks"}Select the DB table to yield your contacts or memberships. Therefore table has to feature a <code>contact_id</code> or <code>membership_id</code> column. Should both exist, the <code>membership_id</code> takes preference and memberships are assigned.{/ts}</p>
+{/htxt}
+
+{htxt id='id-segmentation-assign-segment-name'}
+  <p>{ts domain="de.systopia.sqltasks"}Contacts or memberships will be assigned to this segment. If the segment doesn't exist yet, it will be created.{/ts}</p>
+{/htxt}
+
+{htxt id='id-segmentation-assign-clear'}
+  <p>{ts domain="de.systopia.sqltasks"}Caution: this option will clear the campaign before assigning new contacts. That means all previous assignments will be removed - regardless of the campaign's status.{/ts}</p>
+{/htxt}
+
+{htxt id='id-segmentation-assign-segment-from-table'}
+  <p>{ts domain="de.systopia.sqltasks"}If this option is activated, the segment the contacts or memberships will be assigned to will be taken from the table column <code>segment_name</code>. This column has to exist and cannot be empty.{/ts}</p>
+  <p>{ts domain="de.systopia.sqltasks"}In this case the segment name entered above is ignored.{/ts}</p>
+{/htxt}
+
+{htxt id='id-segmentation-assign-start'}
+  <p>{ts domain="de.systopia.sqltasks"}Do you want to update the campaign's status after your assignment? You have four options:{/ts}</p>
+  <ul>
+    <li>{ts domain="de.systopia.sqltasks"}"don't change status": Don't touch anything here{/ts}</li>
+    <li>{ts domain="de.systopia.sqltasks"}"(re)set to 'planned'": Set the status to 'planned', regardless of the previous state{/ts}</li>
+    <li>{ts domain="de.systopia.sqltasks"}"(re)start with fixed segment order": Start the campaign, even if it was already started. For this we need a segment order, which can be entered in the text field below.{/ts}</li>
+    <li>{ts domain="de.systopia.sqltasks"}"(re)start with segment order from table": Same as the last one, but taking the segment order from a DB table.{/ts}</li>
+  </ul>
+{/htxt}
+
+{htxt id='id-segmentation-assign-segment-order'}
+  <p>{ts domain="de.systopia.sqltasks"}Here you can provide a segment hierarchy by listing the segment names in the right order. One segment name per line, no separator charactes like ','. Make sure the names are spelled correctly.{/ts}</p>
+{/htxt}
+
+{htxt id='id-segmentation-assign-segment-order-table'}
+  <p>{ts domain="de.systopia.sqltasks"}The table referenced here needs to feature the following two columns:{/ts}</p>
+  <ul>
+    <li>{ts domain="de.systopia.sqltasks"}<code>segment_name</code>: The name of the segment (as in <code>civicrm_segmentation_index</code>). Will be created if it doesn't exist.{/ts}</li>
+    <li>{ts domain="de.systopia.sqltasks"}<code>segment_weight</code>: A numeric weight value of the segment, lower value means higher ranking.{/ts}</li>
+  </ul>
+{/htxt}

--- a/templates/CRM/Sqltasks/Action/SegmentationExport.hlp
+++ b/templates/CRM/Sqltasks/Action/SegmentationExport.hlp
@@ -1,0 +1,50 @@
+{*-------------------------------------------------------+
+| SYSTOPIA SQL TASKS EXTENSION                           |
+| Copyright (C) 2017 SYSTOPIA                            |
+| Author: B. Endres (endres@systopia.de)                 |
++--------------------------------------------------------+
+| This program is released as free software under the    |
+| Affero GPL license. You can redistribute it and/or     |
+| modify it under the terms of this license which you    |
+| can read by viewing the included agpl.txt or online    |
+| at www.gnu.org/licenses/agpl.html. Removal of this     |
+| copyright header is strictly prohibited without        |
+| written permission from the original author(s).        |
++-------------------------------------------------------*}
+
+{htxt id='id-segmentation-export-datetime'}
+  <p>{ts domain="de.systopia.sqltasks"}You can use any string as processed by PHP's <code>strtotime</code> function, see <a href="https://secure.php.net/manual/en/datetime.formats.php">HERE</a>.{/ts}</p>
+  <p>
+    {ts domain="de.systopia.sqltasks"}Examples:{/ts}
+    <ul>
+      <li>{ts domain="de.systopia.sqltasks"}<code>now</code>{/ts}</li>
+      <li>{ts domain="de.systopia.sqltasks"}<code>now + 2 days</code>{/ts}</li>
+      <li>{ts domain="de.systopia.sqltasks"}<code>tomorrow</code>{/ts}</li>
+    </ul>
+  </p>
+  <p>{ts domain="de.systopia.sqltasks"}The default is <code>now</code>.{/ts}</p>
+{/htxt}
+
+{htxt id='id-segmentation-export-current'}
+  <p>{ts domain="de.systopia.sqltasks"}If yo select this, the date frame will be automatically set to the time used by the 'Assign to Campaign' task above.{/ts}</p>
+{/htxt}
+
+{htxt id='id-segmentation-export-email'}
+  <p>{ts domain="de.systopia.sqltasks"}You can specify a comma separated list of email addresses that the resulting file will be sent to.{/ts}</p>
+  <p>{ts domain="de.systopia.sqltasks"}<strong>Caution!</strong> The data will be sent unencrypted. Please do not use this option if the resulting files contains sensitive data.{/ts}</p>
+{/htxt}
+
+{htxt id='id-segmentation-export-filename'}
+  <p>{ts domain="de.systopia.sqltasks"}The file name of the resulting CSV file.{/ts}</p>
+  <p>{ts domain="de.systopia.sqltasks"}You can use the token {literal}<code>{xxx}</code>{/literal}, which will be replaced by a current date string. The format (i.e. the xxx) is defined <a href="https://secure.php.net/manual/en/function.date.php#refsect1-function.date-parameters">here</a>. An example would be <code>{literal}{Y-m-d}{/literal}</code>.{/ts}</p>
+  <p>{ts domain="de.systopia.sqltasks"}Additionally, you can use the tokens {literal}<code>{campaign_id}</code>{/literal}, {literal}<code>{campaign_title}</code>{/literal} and {literal}<code>{campaign_external_identifier}</code>{/literal}, which obviously refer to the selected campaign.{/ts}</p>
+{/htxt}
+
+{htxt id='id-segmentation-export-path'}
+  <p>{ts domain="de.systopia.sqltasks"}This defines the path about where the resulting file is stored. If you leave it empty, a default path will be used.{/ts}</p>
+{/htxt}
+
+{htxt id='id-segmentation-export-sftp'}
+  <p>{ts domain="de.systopia.sqltasks"}Define the target SFTP path to upload your file to. The format is <code>sftp://user:password@host/path</code>, e.g. <code>sftp://reports:123456@www.reports-server.de/civic-reports</code>{/ts}</p>
+  <p>{ts domain="de.systopia.sqltasks"}<strong>Caution!</strong> These credentials will be stored in the CiviCRM database unencrypted. Please don't use sensitive accounts for uploading files.{/ts}</p>
+{/htxt}

--- a/templates/CRM/Sqltasks/Form/Configure.hlp
+++ b/templates/CRM/Sqltasks/Form/Configure.hlp
@@ -1,0 +1,50 @@
+{*-------------------------------------------------------+
+| SYSTOPIA SQL TASKS EXTENSION                           |
+| Copyright (C) 2017 SYSTOPIA                            |
+| Author: B. Endres (endres@systopia.de)                 |
++--------------------------------------------------------+
+| This program is released as free software under the    |
+| Affero GPL license. You can redistribute it and/or     |
+| modify it under the terms of this license which you    |
+| can read by viewing the included agpl.txt or online    |
+| at www.gnu.org/licenses/agpl.html. Removal of this     |
+| copyright header is strictly prohibited without        |
+| written permission from the original author(s).        |
++-------------------------------------------------------*}
+
+
+{htxt id='id-configure-description'}
+  <p>{ts domain="de.systopia.sqltasks"}Describing comprehensively what your task does is essential for anyone to understand whether it's safe to run or disable it. That includes yourself in six months, when you will have forgotten all about this.{/ts}</p>
+{/htxt}
+
+{htxt id='id-configure-category'}
+  <p>{ts domain="de.systopia.sqltasks"}This is merely for documentation purposes, you can pick any name you want.{/ts}</p>
+{/htxt}
+
+{htxt id='id-configure-parallel'}
+  <p>{ts domain="de.systopia.sqltasks"}If you enable this flag, this task will be executed even if other tasks are still running.{/ts}</p>
+  <p>{ts domain="de.systopia.sqltasks"}It does <i>not</i> mean, that this task itself will be executed in multiple instances at the same time.{/ts}</p>
+{/htxt}
+
+{htxt id='id-configure-main'}
+  <p>{ts domain="de.systopia.sqltasks"}This is the main script. You can use it to create a helper table or view to drive the actions listed below. Of course you could also use this script to perform the required changes right in the DB, but this is usually discouraged as it bypasses CiviCRM logic.{/ts}</p>
+  <p>{ts domain="de.systopia.sqltasks"}You can paste and run <i>any</i> complete SQL script in here. <strong>But beware</strong>: with great power comes great responsibility!{/ts}</p>
+  <p>{ts domain="de.systopia.sqltasks"}{/ts}</p>
+  <p>{ts domain="de.systopia.sqltasks"}We recommend developing complex SQL scripts in an external editor, and simply copy/pasting it here.{/ts}</p>
+{/htxt}
+
+{htxt id='id-configure-post'}
+  <p>{ts domain="de.systopia.sqltasks"}It's considered good practice to clean up any helper tables that you created with the main script. This way you can make sure that you don't leave any dependencies behind.{/ts}</p>
+{/htxt}
+
+{htxt id='id-configure-exectime'}
+  <p>{ts domain="de.systopia.sqltasks"}Set the exact <i>Weekday / Day / Hour / Minute</i> when the job will be executed, on the first cron call after this datetime.{/ts}</p>
+{/htxt}
+
+{htxt id='id-user-input'}
+  <p>{ts domain="de.systopia.sqltasks"}If you enable this flag, execution of this task requires an input value. The value may be entered manually by the user before execution, or it could be provided programmatically via the API or e.g. by the CiviRules action integration. The input value will be provided as an SQL variable called <strong>@input</strong> within the main script.{/ts}</p>
+{/htxt}
+
+{htxt id='id-run-permissions'}
+  <p>{ts domain="de.systopia.sqltasks"}List of permissions which will be checked before task is ran.{/ts}</p>
+{/htxt}


### PR DESCRIPTION
This adds back all `.hlp` files which were removed by 8a1d5d55ce28e8a344f21c978e989496433ca999 but are still in use for the help tooltips.