### PR TITLE
GP-7210 Add global tokens

### DIFF
--- a/CRM/Sqltasks/Action/APICall.php
+++ b/CRM/Sqltasks/Action/APICall.php
@@ -52,7 +52,6 @@ class CRM_Sqltasks_Action_APICall extends CRM_Sqltasks_Action {
    */
   protected function getDataTable() {
     $table_name = $this->getConfigValue('table');
-    $this->resolveTableToken($table_name);
     return trim($table_name);
   }
 

--- a/CRM/Sqltasks/Action/CSVExport.php
+++ b/CRM/Sqltasks/Action/CSVExport.php
@@ -106,7 +106,6 @@ class CRM_Sqltasks_Action_CSVExport extends CRM_Sqltasks_Action {
    */
   protected function getExportTable() {
     $table_name = $this->getConfigValue('table');
-    $this->resolveTableToken($table_name);
     return trim($table_name);
   }
 

--- a/CRM/Sqltasks/Action/ContactSet.php
+++ b/CRM/Sqltasks/Action/ContactSet.php
@@ -25,7 +25,6 @@ abstract class CRM_Sqltasks_Action_ContactSet extends CRM_Sqltasks_Action {
    */
   public function getContactTable() {
     $table_name = $this->getConfigValue('contact_table');
-    $this->resolveTableToken($table_name);
     return trim($table_name);
   }
 

--- a/CRM/Sqltasks/Action/ResultHandler.php
+++ b/CRM/Sqltasks/Action/ResultHandler.php
@@ -241,8 +241,6 @@ abstract class CRM_Sqltasks_Action_ResultHandler extends CRM_Sqltasks_Action {
       return NULL;
     }
 
-    $this->resolveTableToken($error_table);
-
     // make sure the table exists
     $error_table = trim($error_table);
     $existing_table = CRM_Core_DAO::singleValueQuery("SHOW TABLES LIKE '{$error_table}';");

--- a/CRM/Sqltasks/Action/SegmentationAssign.php
+++ b/CRM/Sqltasks/Action/SegmentationAssign.php
@@ -96,7 +96,6 @@ class CRM_Sqltasks_Action_SegmentationAssign extends CRM_Sqltasks_Action {
     if ($status_change == 'restart_t') {
       // get the order from the table
       $table_name = $this->getConfigValue('segment_order_table');
-      $this->resolveTableToken($table_name);
       $segment_colum = CRM_Core_DAO::singleValueQuery("SHOW COLUMNS FROM `{$table_name}` LIKE 'segment_name';");
       if (!$segment_colum) {
         throw new Exception("Segmentation order table '{$table_name}' has no column 'segment_name'.", 1);
@@ -119,7 +118,6 @@ class CRM_Sqltasks_Action_SegmentationAssign extends CRM_Sqltasks_Action {
    */
   protected function getDataTable() {
     $table_name = $this->getConfigValue('table');
-    $this->resolveTableToken($table_name);
     return trim($table_name);
   }
 
@@ -380,7 +378,6 @@ class CRM_Sqltasks_Action_SegmentationAssign extends CRM_Sqltasks_Action {
     if ($status_change == 'restart_t') {
       // get the order from the table
       $table_name = $this->getConfigValue('segment_order_table');
-      $this->resolveTableToken($table_name);
       $query = CRM_Core_DAO::executeQuery("SELECT DISTINCT(`segment_name`) AS sname FROM `{$table_name}` ORDER BY `segment_weight` ASC");
       while ($query->fetch()) {
         // look up segment by name

--- a/api/v3/Sqltask/Execute.php
+++ b/api/v3/Sqltask/Execute.php
@@ -67,4 +67,11 @@ function _civicrm_api3_sqltask_execute_spec(&$params) {
     'title'        => 'Log to a file?',
     'description'  => 'Log task output to a file instead of returning it in the API results?',
   );
+  $params['input_val'] = array(
+    'name'         => 'input_val',
+    'api.required' => 0,
+    'type'         => CRM_Utils_Type::T_STRING,
+    'title'        => 'Input Value',
+    'description'  => 'Input value with execution context. Will be forwarded to all actions',
+  );
 }

--- a/settings/sqltasks.setting.php
+++ b/settings/sqltasks.setting.php
@@ -1,0 +1,14 @@
+<?php
+
+return [
+  'sqltasks_global_tokens' => [
+    'name'        => 'sqltasks_global_tokens',
+    'type'        => 'Array',
+    'default'     => [],
+    'html_type'   => 'text',
+    'title'       => ts('SQL Tasks global tokens'),
+    'is_domain'   => 1,
+    'is_contact'  => 0,
+    'description' => ts('Array of global tokens for SQL Tasks which may be used using the {config.token_name} syntax.'),
+  ],
+];

--- a/tests/fixtures/csvexport_input_val.csv
+++ b/tests/fixtures/csvexport_input_val.csv
@@ -1,0 +1,2 @@
+foo
+expected_value

--- a/tests/phpunit/CRM/Sqltasks/AbstractTaskTest.php
+++ b/tests/phpunit/CRM/Sqltasks/AbstractTaskTest.php
@@ -30,10 +30,10 @@ abstract class CRM_Sqltasks_AbstractTaskTest extends \PHPUnit_Framework_TestCase
     parent::tearDown();
   }
 
-  protected function createAndExecuteTask(array $data) {
+  protected function createAndExecuteTask(array $data, array $params = []) {
     $task = new CRM_Sqltasks_Task(NULL, $data);
     $task->store();
-    $this->log = $task->execute();
+    $this->log = $task->execute($params);
     return $task;
   }
 


### PR DESCRIPTION
This introduces the concept of global tokens. Global tokens are applied to all configuration values of all actions. They use a distinct syntax (`{prefix.key}`) to avoid conflicts with other tokens.

The following token prefixes are currently supported:
- `context.*`: replacements with the current task context (e.g. input_val)
- `setting.*`: replace with the value of a CiviCRM setting
- `config.*`: replace with an item in the `sqltasks_global_tokens` setting. This is useful e.g. as a credentials store.

This design allows for future additions in a central place, rather than having multiple types of tokens.