### PR TITLE
GP-8418 Add "Run PHP" action

### DIFF
--- a/CRM/Sqltasks/Action.php
+++ b/CRM/Sqltasks/Action.php
@@ -91,6 +91,16 @@ abstract class CRM_Sqltasks_Action {
   }
 
   /**
+   * Set a configuration value
+   *
+   * @param $name
+   * @param $value
+   */
+  public function setConfigValue($name, $value) {
+    $this->config[$name] = $value;
+  }
+
+  /**
    * Get a list of ints from the string
    *
    * @param $string

--- a/CRM/Sqltasks/Action/RunPHP.php
+++ b/CRM/Sqltasks/Action/RunPHP.php
@@ -1,0 +1,86 @@
+<?php
+/*-------------------------------------------------------+
+| SYSTOPIA SQL TASKS EXTENSION                           |
+| Copyright (C) 2020 SYSTOPIA                            |
+| Author: P. Figel <pfigel@greenpeace.org>
++--------------------------------------------------------+
+| This program is released as free software under the    |
+| Affero GPL license. You can redistribute it and/or     |
+| modify it under the terms of this license which you    |
+| can read by viewing the included agpl.txt or online    |
+| at www.gnu.org/licenses/agpl.html. Removal of this     |
+| copyright header is strictly prohibited without        |
+| written permission from the original author(s).        |
++--------------------------------------------------------*/
+
+use CRM_Sqltasks_ExtensionUtil as E;
+
+/**
+ * This actions allows you to run arbitrary PHP code
+ *
+ */
+class CRM_Sqltasks_Action_RunPHP extends CRM_Sqltasks_Action {
+
+  /**
+   * Get identifier string
+   */
+  public function getID() {
+    return 'php';
+  }
+
+  /**
+   * Get a human readable name
+   */
+  public function getName() {
+    return E::ts('Run PHP Code');
+  }
+
+  /**
+   * Get default template order
+   *
+   * @return int
+   */
+  public function getDefaultOrder() {
+    return 900;
+  }
+
+  /**
+   * Whether this action should be included in the template for new tasks
+   *
+   * @return bool
+   */
+  public static function isDefaultTemplateAction() {
+    return FALSE;
+  }
+
+  /**
+   * Check if this action is configured correctly
+   *
+   * @throws \Exception
+   */
+  public function checkConfiguration() {
+    parent::checkConfiguration();
+    $entity = $this->getConfigValue('php_code');
+    if (empty($entity)) {
+      throw new Exception('PHP code not provided', 1);
+    }
+  }
+
+  /**
+   * RUN this action
+   *
+   * @throws \Exception
+   */
+  public function execute() {
+    // has_executed is always false for RunSQL
+    $this->resetHasExecuted();
+    try {
+      eval(html_entity_decode($this->getConfigValue('php_code')));
+    }
+    catch (Exception $e) {
+      $this->log("PHP failed: " . $e->getMessage() . " - " . $e->getTraceAsString());
+      throw $e;
+    }
+  }
+
+}

--- a/ang/actions/RunPHP.html
+++ b/ang/actions/RunPHP.html
@@ -1,0 +1,25 @@
+<div class="crm-accordion-wrapper crm-sqltask-php collapsed relativePosition">
+    <div class="crm-accordion-header accordion-header-custom active action-label">
+        <label class="input-checkbox">
+            <input ng-true-value="'1'" style="cursor: pointer;" ng-false-value="'0'" ng-model="ctrl.model['enabled']" type="checkbox">
+            &nbsp;
+            {{ts('Run PHP Code')}}
+        </label>
+        <span ng-if="ctrl.model['action_title']" class="sql-task-action-title">{{ctrl.model['action_title']}}</span>
+        <label class="header-delete-btn" ng-click="removeItemFromArray(ctrl.index)">
+            <i class="crm-i fa-trash header-delete"></i>
+            {{ts('Delete')}}
+        </label>
+    </div>
+    <div class="crm-accordion-body" style="display: none;">
+        <div class="sql-tasks">
+            <action-additional-info model='ctrl.model' fieldPrefix="'php'" index='ctrl.index'></action-additional-info>
+
+            <text-area isrequired="getBooleanFromNumber(ctrl.model['enabled'])" model="ctrl.model['php_code']"
+                fieldlabel="ts('PHP Code')" fieldid="'php_code' + ctrl.index" rowsnumber='8' inputMaxWidth="'500px'"
+                helpaction='onInfoPress("PHP Code", "id-php-code", "CRM\/Sqltasks\/Action\/RunPHP")'
+                showHelpIcon=true>
+            </text-area>
+        </div>
+    </div>
+</div>

--- a/ang/sqlTaskConfigurator.js
+++ b/ang/sqlTaskConfigurator.js
@@ -263,7 +263,9 @@
         $scope.actions = result.values;
         if (!getBooleanFromNumber(taskId)) {
           $scope.actions.forEach(function(value) {
-            $scope.addAction(value.type);
+            if (value.is_default_template) {
+              $scope.addAction(value.type);
+            }
           });
         }
         $scope.$apply();
@@ -332,6 +334,8 @@
             return ts("Assign to Campaign (Segmentation)");
           case "CRM_Sqltasks_Action_SegmentationExport":
             return ts("Segmentation Export");
+          case "CRM_Sqltasks_Action_RunPHP":
+            return ts("Run PHP Code");
           default:
             return "";
         }
@@ -821,6 +825,32 @@
         $scope.removeItemFromArray = removeItemFromArray;
         $scope.getBooleanFromNumber = getBooleanFromNumber;
         $scope.onInfoPress = onInfoPress;
+      }
+    };
+  });
+
+  angular.module(moduleName).directive("runPhp", function() {
+    return {
+      restrict: "E",
+      templateUrl: "~/sqlTaskConfigurator/RunPHP.html",
+      scope: {
+        model: "=",
+        index: "<"
+      },
+      bindToController: true,
+      controllerAs: "ctrl",
+      controller: function($scope) {
+        $scope.ts = CRM.ts();
+        $scope.removeItemFromArray = removeItemFromArray;
+        $scope.getBooleanFromNumber = getBooleanFromNumber;
+        $scope.onInfoPress = onInfoPress;
+        $scope.onPhpCodePress = function() {
+          CRM.help("PHP Code", {
+            id: "id-php-code",
+            file: "CRM/Sqltasks/Action/RunPHP"
+          });
+          return false;
+        };
       }
     };
   });

--- a/ang/sqlTaskConfigurator/sqlTaskConfigurator.html
+++ b/ang/sqlTaskConfigurator/sqlTaskConfigurator.html
@@ -383,6 +383,9 @@
                                 <div ng-switch-when="CRM_Sqltasks_Action_ErrorHandler">
                                     <error-handler model='action' index='$index'></error-handler>
                                 </div>
+                              <div ng-switch-when="CRM_Sqltasks_Action_RunPHP">
+                                <run-php model='action' index='$index'></run-php>
+                              </div>
                                 <div ng-switch-default></div>
                             </div>
                         </div>

--- a/templates/CRM/Sqltasks/Action/RunPHP.hlp
+++ b/templates/CRM/Sqltasks/Action/RunPHP.hlp
@@ -1,0 +1,19 @@
+{*-------------------------------------------------------+
+| SYSTOPIA SQL TASKS EXTENSION                           |
+| Copyright (C) 2020 SYSTOPIA                            |
+| Author: P. Figel <pfigel@greenpeace.org>               |
++--------------------------------------------------------+
+| This program is released as free software under the    |
+| Affero GPL license. You can redistribute it and/or     |
+| modify it under the terms of this license which you    |
+| can read by viewing the included agpl.txt or online    |
+| at www.gnu.org/licenses/agpl.html. Removal of this     |
+| copyright header is strictly prohibited without        |
+| written permission from the original author(s).        |
++-------------------------------------------------------*}
+
+{htxt id='id-php-code'}
+  <p>{ts domain="de.systopia.sqltasks"}This is the PHP code that is executed in the context of an instance of <code>CRM_Sqltasks_Action_RunPHP</code>.{/ts}</p>
+  <p>{ts domain="de.systopia.sqltasksd"}You can run arbitrary PHP code here. Please refer to <code>CRM_Sqltasks_Action_RunPHP</code> for available methods and properties. You may also call any other function, class or method available in CiviCRM. <strong>But beware</strong>: with great power comes great responsibility!{/ts}</p>
+  <p>{ts domain="de.systopia.sqltasks"}Is is highly recommended to only use this action in exceptional circumstances. Almost all tasks should be implemented using a combination of SQL and any of the other available actions.{/ts}</p>
+{/htxt}

--- a/tests/phpunit/CRM/Sqltasks/Action/RunPHPTest.php
+++ b/tests/phpunit/CRM/Sqltasks/Action/RunPHPTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * Test RunPHP Action
+ *
+ * @group headless
+ */
+class CRM_Sqltasks_Action_RunPHPTest extends CRM_Sqltasks_Action_AbstractActionTest {
+
+  public function tearDown() {
+    CRM_Core_DAO::executeQuery('DROP TABLE IF EXISTS tmp_test_action_php');
+    parent::tearDown();
+  }
+
+  public function testRunPHP() {
+    $data = [
+      'version' => CRM_Sqltasks_Config_Format::CURRENT,
+      'actions' => [
+        [
+          'type'    => 'CRM_Sqltasks_Action_RunSQL',
+          'enabled' => TRUE,
+          'script'  => "DROP TABLE IF EXISTS tmp_test_action_php;
+                        CREATE TABLE tmp_test_action_php AS " . self::TEST_CONTACT_SQL,
+        ],
+        [
+          'type'     => 'CRM_Sqltasks_Action_RunPHP',
+          'enabled'  => TRUE,
+          'php_code' => "CRM_Core_DAO::executeQuery('TRUNCATE TABLE tmp_test_action_php');"
+        ],
+      ]
+    ];
+    $this->createAndExecuteTask($data);
+
+    $this->assertLogContains("Action 'Run PHP Code' executed in", 'Run PHP action should have succeeded');
+    $count = CRM_Core_DAO::singleValueQuery("SELECT COUNT(1) FROM tmp_test_action_php");
+    $this->assertEquals(0, $count, 'Table tmp_test_action_php should have been truncated');
+  }
+
+}


### PR DESCRIPTION
This adds a new action type that allows execution of arbitrary PHP code in the context of an instance of `CRM_Sqltasks_Action_RunPHP`.

This action type can be used to call any function, class or method available in CiviCRM. Given the context it is executing in, it can also change the task at execution time, which may be useful for complex control flows.