### PR TITLE
GP-8323: Add ability to archive tasks.

### DIFF
--- a/CRM/Sqltasks/Task.php
+++ b/CRM/Sqltasks/Task.php
@@ -33,7 +33,6 @@ class CRM_Sqltasks_Task {
     'last_runtime'    => 'Integer',
     'parallel_exec'   => 'Integer',
     'run_permissions' => 'String',
-    'is_archived'     => 'Integer',
     'archive_date'    => 'String',
     // REMOVED - DO NOT USE
     'main_sql'        => 'String',
@@ -90,7 +89,6 @@ class CRM_Sqltasks_Task {
     $defaults = [
       'parallel_exec'  => 0,
       'input_required' => 0,
-      'is_archived' => 0,
     ];
     foreach ($defaults as $attribute => $value) {
       if (empty($this->attributes[$attribute])) {
@@ -110,7 +108,7 @@ class CRM_Sqltasks_Task {
    * Is task archived?
    */
   public function isArchived() {
-    return $this->getAttribute('is_archived') == 1;
+    return !empty($this->getAttribute('archive_date'));
   }
 
   /**
@@ -536,6 +534,7 @@ class CRM_Sqltasks_Task {
     unset($config['weight']);
     unset($config['last_execution']);
     unset($config['last_runtime']);
+    unset($config['archive_date']);
     $config['config'] = $this->config;
     return json_encode($config, JSON_PRETTY_PRINT);
   }
@@ -836,7 +835,7 @@ class CRM_Sqltasks_Task {
       'next_execution' => 'TODO',
       'enabled'        => (empty($this->getAttribute('enabled'))) ? 0 : 1,
       'config'         => $this->getConfiguration(),
-      'is_archived'    => $this->getAttribute('is_archived'),
+      'is_archived'    => $this->isArchived(),
       'archive_date'   => (empty($this->getAttribute('archive_date'))) ? '' : $this->getAttribute('archive_date'),
     ];
 
@@ -913,17 +912,17 @@ class CRM_Sqltasks_Task {
    * Archive the task
    */
   public function archive() {
-    $this->setAttribute('is_archived', '1', TRUE);
-    $this->setAttribute('enabled', '0', TRUE);
-    $this->setAttribute('archive_date', date('Y-m-d H:i:s'), TRUE);
+    $this->setAttribute('enabled', 0);
+    $this->setAttribute('archive_date', date('Y-m-d H:i:s'));
+    $this->store();
   }
 
   /**
    * Unarchive the task
    */
   public function unarchive() {
-    $this->setAttribute('is_archived', '0', TRUE);
-    $this->setAttribute('archive_date', 'NULL', TRUE);
+    $this->setAttribute('archive_date', NULL);
+    $this->store();
   }
 
 }

--- a/CRM/Sqltasks/Upgrader.php
+++ b/CRM/Sqltasks/Upgrader.php
@@ -107,7 +107,6 @@ class CRM_Sqltasks_Upgrader extends CRM_Sqltasks_Upgrader_Base {
     // upgrades from < 0.8.2 to >= 0.9 as CRM_Sqltasks_Task::store() relies
     // on the column being present.
     $this->addInputRequired();
-    $this->addIsArchivedColumn();
     $this->addArchiveDateColumn();
     $tasks = CRM_Sqltasks_Task::getAllTasks();
     foreach ($tasks as $task) {

--- a/CRM/Sqltasks/Upgrader.php
+++ b/CRM/Sqltasks/Upgrader.php
@@ -260,4 +260,16 @@ class CRM_Sqltasks_Upgrader extends CRM_Sqltasks_Upgrader_Base {
     return TRUE;
   }
 
+  /**
+   * Add 'archive_date' column to 'civicrm_sqltasks' table if column doesn't exist
+   *
+   * @return bool
+   * @throws \Exception
+   */
+  public function upgrade_0120() {
+    $this->addArchiveDateColumn();
+
+    return TRUE;
+  }
+
 }

--- a/ang/sqlTaskConfigurator/sqlTaskConfigurator.html
+++ b/ang/sqlTaskConfigurator/sqlTaskConfigurator.html
@@ -406,7 +406,7 @@
         </div>
 
         <div class="crm-submit-buttons">
-            <button ng-disabled="taskOptions.is_archived" class="crm-form-submit default validate" crm-icon="fa-check" name="_qf_Configure_submit"
+            <button ng-disabled="getBooleanFromNumber(ttaskOptions.is_archived)" class="crm-form-submit default validate" crm-icon="fa-check" name="_qf_Configure_submit"
                     type="button" id="_qf_Configure_submit-bottom">
               {{getBooleanFromNumber(taskId) ? ts('Save') : ts('Create')}}
             </button>

--- a/ang/sqlTaskConfigurator/sqlTaskConfigurator.html
+++ b/ang/sqlTaskConfigurator/sqlTaskConfigurator.html
@@ -13,7 +13,7 @@
             </div>
 
             <div class="status" ng-if="taskOptions.is_archived == 1">
-              <span>{{ts('This task has been archived from %1 and cannot be changed. Please unarchive the task to change it.', { '1' : taskOptions.archive_date })}}</span>
+              <span>{{ts('This task was archived at %1 and cannot be changed. Please unarchive the task to change it.', { '1' : taskOptions.archive_date })}}</span>
             </div>
 
             <div class="sql-tasks-basic-information-block">

--- a/ang/sqlTaskConfigurator/sqlTaskConfigurator.html
+++ b/ang/sqlTaskConfigurator/sqlTaskConfigurator.html
@@ -12,6 +12,10 @@
                 </div>
             </div>
 
+            <div class="status" ng-if="taskOptions.is_archived == 1">
+              <span>{{ts('This task has been archived from %1 and cannot be changed. Please unarchive the task to change it.', { '1' : taskOptions.archive_date })}}</span>
+            </div>
+
             <div class="sql-tasks-basic-information-block">
                 <h3>{{ts('Basic Information')}}:</h3>
                 <div class="spacer"></div>
@@ -402,7 +406,7 @@
         </div>
 
         <div class="crm-submit-buttons">
-            <button class="crm-form-submit default validate" crm-icon="fa-check" name="_qf_Configure_submit"
+            <button ng-disabled="taskOptions.is_archived" class="crm-form-submit default validate" crm-icon="fa-check" name="_qf_Configure_submit"
                     type="button" id="_qf_Configure_submit-bottom">
               {{getBooleanFromNumber(taskId) ? ts('Save') : ts('Create')}}
             </button>

--- a/ang/sqlTaskConfigurator/sqlTaskConfigurator.html
+++ b/ang/sqlTaskConfigurator/sqlTaskConfigurator.html
@@ -406,7 +406,7 @@
         </div>
 
         <div class="crm-submit-buttons">
-            <button ng-disabled="getBooleanFromNumber(ttaskOptions.is_archived)" class="crm-form-submit default validate" crm-icon="fa-check" name="_qf_Configure_submit"
+            <button ng-disabled="getBooleanFromNumber(taskOptions.is_archived)" class="crm-form-submit default validate" crm-icon="fa-check" name="_qf_Configure_submit"
                     type="button" id="_qf_Configure_submit-bottom">
               {{getBooleanFromNumber(taskId) ? ts('Save') : ts('Create')}}
             </button>

--- a/ang/sqlTaskManager.js
+++ b/ang/sqlTaskManager.js
@@ -185,7 +185,7 @@
 
         CRM.api3("Sqltask", "unarchive", {id: taskId}).done(function(result) {
           if (result.values && !result.is_error) {
-            CRM.alert(ts('Task has successfully unarchived'), ts("Unarchiving task"), "success");
+            CRM.alert(ts('Task was successfully unarchived'), ts("Unarchiving task"), "success");
             $scope.tasks[index] = result.values;
             $scope.$apply();
           } else {
@@ -203,7 +203,7 @@
 
         CRM.api3("Sqltask", "archive", {id: taskId}).done(function(result) {
           if (result.values && !result.is_error) {
-            CRM.alert(ts('Task has successfully archived'), ts("Archiving task"), "success");
+            CRM.alert(ts('Task was successfully archived'), ts("Archiving task"), "success");
             $scope.tasks[index] = result.values;
             $scope.$apply();
           } else {

--- a/ang/sqlTaskManager.js
+++ b/ang/sqlTaskManager.js
@@ -155,28 +155,61 @@
 
       $scope.onToggleEnablePress = function(taskId, value) {
         var index = $scope.tasks.findIndex(el => el.id === taskId);
-        if (index !== -1) {
-          CRM.api3("Sqltask", "create", {
-            id: taskId,
-            enabled: value
-          }).done(function(result) {
-            if (result.values && !result.is_error) {
-              CRM.alert(
-                ts("Task enabled / disabled successfully"),
-                ts("Enable / disable task"),
-                "success"
-              );
-              $scope.tasks[index] = result.values;
-              $scope.$apply();
-            } else {
-              CRM.alert(
-                ts("Error enabling / disabing task"),
-                ts("Enable / disable task"),
-                "error"
-              );
-            }
-          });
+        var isEnabling = value == 1;
+        if (index === -1) {
+          CRM.alert(ts("Can't find task index. You can refresh page and try it again."), ts("Error enabling/disabling task"), "error");
+          return;
         }
+
+        CRM.api3("Sqltask", "create", {
+          id: taskId,
+          enabled: value
+        }).done(function(result) {
+          if (result.values && !result.is_error) {
+            var successMessageTitle = (isEnabling ? 'Enabling' : 'Disabling') + ' task';
+            CRM.alert(ts('Task has successfully ' + (isEnabling ? 'enabled' : 'disabled')), ts(successMessageTitle), "success");
+            $scope.tasks[index] = result.values;
+            $scope.$apply();
+          } else {
+            CRM.alert(result.error_message, ts('Error ' + (isEnabling ? 'enabling' : 'disabling' + ' task'), "error"));
+          }
+        });
+      };
+
+      $scope.onUnarchivePress = function(taskId) {
+        var index = $scope.tasks.findIndex(el => el.id === taskId);
+        if (index === -1) {
+          CRM.alert(ts("Can't find task index. You can refresh page and try it again."), ts("Error unarchiving task"), "error");
+          return;
+        }
+
+        CRM.api3("Sqltask", "unarchive", {id: taskId}).done(function(result) {
+          if (result.values && !result.is_error) {
+            CRM.alert(ts('Task has successfully unarchived'), ts("Unarchiving task"), "success");
+            $scope.tasks[index] = result.values;
+            $scope.$apply();
+          } else {
+            CRM.alert(result.error_message, ts("Error unarchiving task"), "error");
+          }
+        });
+      };
+
+      $scope.onArchivePress = function(taskId) {
+        var index = $scope.tasks.findIndex(el => el.id === taskId);
+        if (index === -1) {
+          CRM.alert(ts("Can't find task id. You can refresh page and try it again."), ts("Error archiving task"), "error");
+          return;
+        }
+
+        CRM.api3("Sqltask", "archive", {id: taskId}).done(function(result) {
+          if (result.values && !result.is_error) {
+            CRM.alert(ts('Task has successfully archived'), ts("Archiving task"), "success");
+            $scope.tasks[index] = result.values;
+            $scope.$apply();
+          } else {
+            CRM.alert(result.error_message, ts("Error archiving task"), "error");
+          }
+        });
       };
 
       $scope.onDeletePress = function(taskId) {

--- a/ang/sqlTaskManager/sqlTaskManager.html
+++ b/ang/sqlTaskManager/sqlTaskManager.html
@@ -69,14 +69,14 @@
             <td>[{{task.id}}]</td>
             <td>
                 <span>{{task.name}}</span>
-                <span ng-if="getNumberFromString(task.is_archived)" class="sql-task-archive-message">({{ts('Archived from %1)', { '1' : task.archive_date})}}</span>
+                <div ng-if="getNumberFromString(task.is_archived)" class="sql-task-archive-message">{{ts('Archived at %1', { '1' : task.archive_date})}}</div>
             </td>
             <td>
                 <div title="{{task.description}}">{{task.short_desc}}</div>
             </td>
             <td>{{getNumberFromString(task.enabled) ? 'Yes' : 'No'}}</td>
             <td>
-                <p>{{task.schedule_label}}</p>
+                <span>{{task.schedule_label}}</span>
                 <span ng-if="getBooleanFromNumber(task.parallel_exec)"><strong>{{ts('(parallel)')}}</strong></span>
             </td>
             <td>{{task.last_executed}}</td>
@@ -116,7 +116,7 @@
                             <a ng-href="#/sqltasks/configure/{{task.id}}"
                                 class="action-item crm-hover-button small-popup"
                                 title="{{ts('Configure', {'domain' : 'de.systopia.sqltasks'})}}">
-                                {{ts(getNumberFromString(task.is_archived) ? 'Configure(only view)' : 'Configure', {'domain' : 'de.systopia.sqltasks'})}}
+                                {{ts(getNumberFromString(task.is_archived) ? 'Configure (read-only)' : 'Configure', {'domain' : 'de.systopia.sqltasks'})}}
                             </a>
                         </li>
                         <li ng-if="!getNumberFromString(task.is_archived)" >
@@ -137,7 +137,7 @@
                                 {{ts('Delete', {'domain' : 'de.systopia.sqltasks'})}}
                             </a>
                         </li>
-                        <li ng-if="!getNumberFromString(task.is_archived)" >
+                        <li ng-if="!getNumberFromString(task.is_archived) && !getNumberFromString(task.enabled)" >
                             <a ng-click="onArchivePress(task.id)" class="action-item crm-hover-button small-popup"
                                 title="{{ts('Archive', {'domain' : 'de.systopia.sqltasks'})}}">
                                 {{ts('Archive', {'domain' : 'de.systopia.sqltasks'})}}

--- a/ang/sqlTaskManager/sqlTaskManager.html
+++ b/ang/sqlTaskManager/sqlTaskManager.html
@@ -10,141 +10,158 @@
         </div>
     </div>
     <div>
-        {{ts('You might want to')}} <a ng-href="#/sqltasks/configure/0">{{ts('ADD A NEW ONE')}}</a>. {{ts('Check out
-        our')}} <a href="https://github.com/systopia/de.systopia.sqltasks/blob/master/tasks/readme.md"
-            target="_blank">{{ts('REPOSITORY')}}</a> {{ts('for examples to get you
-        started.')}}</a>
+        {{ts('You might want to')}} <a ng-href="#/sqltasks/configure/0">{{ts('ADD A NEW ONE')}}</a>.
+        {{ts('Check out our')}}
+        <a href="https://github.com/systopia/de.systopia.sqltasks/blob/master/tasks/readme.md" target="_blank">{{ts('REPOSITORY')}}</a>
+          {{ts('for examples to get you started.')}}
+        </a>
     </div>
 </div>
 <br />
+
 <div class="help">
     <div ng-switch on="dispatcher_frequency">
         <div ng-switch-when="Daily">
             {{ts('The dispatcher is run')}}
             <strong>{{ts('every day')}}</strong>
-            {{ts('after midnight. This is
-                            effectively the maximum frequency these taks are being executed with.')}}
-    </div>
-    <div ng-switch-when="Hourly">
-        {{ts('The dispatcher is run')}} <strong>{{ts('every hour')}}</strong> {{ts('on the hour. This is
-                    effectively
-                    the maximum frequency these taks are being executed with.')}}
-    </div>
-    <div ng-switch-when="Always">
-        {{ts('The dispatcher (and therefore all active tasks) will be triggered')}}
-        <strong>{{ts('with
-                        every cron-run')}}</strong>. {{ts('Ask your administrator how often that is, in order to know the effective
-                    maximum
-                    frequency these taks are being executed with.')}}
-    </div>
-    <div ng-switch-default>
-        {{ts('The dispatcher is currently')}} <strong>{{ts('disabled')}}</strong>, {{ts('none of the tasks
-                    will be
-                    executed automatically.')}}
+            {{ts('after midnight. This is effectively the maximum frequency these tasks are being executed with.')}}
+        </div>
+        <div ng-switch-when="Hourly">
+            {{ts('The dispatcher is run')}}
+            <strong>{{ts('every hour')}}</strong>
+            {{ts('on the hour. This is effectively the maximum frequency these tasks are being executed with.')}}
+        </div>
+        <div ng-switch-when="Always">
+            {{ts('The dispatcher (and therefore all active tasks) will be triggered')}}
+            <strong>{{ts('with every cron-run')}}</strong>.
+            {{ts('Ask your administrator how often that is, in order to know the effective maximum frequency these tasks are being executed with.')}}
+        </div>
+        <div ng-switch-default>
+            {{ts('The dispatcher is currently')}}
+            <strong>{{ts('disabled')}}</strong>,
+            {{ts('none of the tasks will be executed automatically.')}}
+        </div>
     </div>
 </div>
-</div>
+
 <br />
 
-<table class="display" id="option11">
+<table class="display">
     <thead>
         <tr>
-            <th class="sorting_disabled" rowspan="1" colspan="1">{{ts('Category')}}
-            </th>
+            <th class="sorting_disabled" rowspan="1" colspan="1">{{ts('Category')}}</th>
             <th class="sorting_disabled" rowspan="1" colspan="1">{{ts('ID')}}</th>
-            <th class="sorting_disabled" rowspan="1" colspan="1">{{ts('Name')}}
-            </th>
-            <th class="sorting_disabled" rowspan="1" colspan="1">
-                {{ts('Description')}}</th>
-            <th class="sorting_disabled" rowspan="1" colspan="1">{{ts('Enabled?')}}
-            </th>
-            <th class="sorting_disabled" rowspan="1" colspan="1">{{ts('Schedule')}}
-            </th>
-            <th class="sorting_disabled" rowspan="1" colspan="1">
-                {{ts('Last Execution')}}</th>
-            <th class="sorting_disabled" rowspan="1" colspan="1">
-                {{ts('Last Runtime')}}</th>
-            <th class="sorting_disabled" rowspan="1" colspan="1">
-                {{ts('Selection Order')}}</th>
+            <th class="sorting_disabled" rowspan="1" colspan="1">{{ts('Name')}}</th>
+            <th class="sorting_disabled" rowspan="1" colspan="1">{{ts('Description')}}</th>
+            <th class="sorting_disabled" rowspan="1" colspan="1">{{ts('Enabled?')}}</th>
+            <th class="sorting_disabled" rowspan="1" colspan="1">{{ts('Schedule')}}</th>
+            <th class="sorting_disabled" rowspan="1" colspan="1">{{ts('Last Execution')}}</th>
+            <th class="sorting_disabled" rowspan="1" colspan="1">{{ts('Last Runtime')}}</th>
+            <th class="sorting_disabled" rowspan="1" colspan="1">{{ts('Selection Order')}}</th>
             <th class="sorting_disabled" rowspan="1" colspan="1"></th>
             <th class="sorting_disabled" rowspan="1" colspan="1"></th>
         </tr>
     </thead>
     <tbody ui-sortable="sortableOptions" id="sortable-tasks" class="ui-sortable tasks-table" ng-model="tasks">
         <tr ng-repeat="task in tasks" id="{{task.id}}" data-task-id="{{task.id}}" class="sql-task-row-item"
-            ng-class="{disabled : !getNumberFromString(task.enabled), 'odd-row': $odd, 'even-row': $even}">
-            <td>{{task.category}}</div>
-            </td>
+            ng-class="{enabled : getNumberFromString(task.enabled), disabled : !getNumberFromString(task.enabled), 'odd-row': $odd, 'even-row': $even, archived: getNumberFromString(task.is_archived)}">
+            <td>{{task.category}}</td>
             <td>[{{task.id}}]</td>
-            <td>{{task.name}}</td>
+            <td>
+                <span>{{task.name}}</span>
+                <span ng-if="getNumberFromString(task.is_archived)" class="sql-task-archive-message">({{ts('Archived from %1)', { '1' : task.archive_date})}}</span>
+            </td>
             <td>
                 <div title="{{task.description}}">{{task.short_desc}}</div>
             </td>
             <td>{{getNumberFromString(task.enabled) ? 'Yes' : 'No'}}</td>
             <td>
-                {{task.schedule_label}}
-                <br />
+                <p>{{task.schedule_label}}</p>
                 <span ng-if="getBooleanFromNumber(task.parallel_exec)"><strong>{{ts('(parallel)')}}</strong></span>
             </td>
             <td>{{task.last_executed}}</td>
             <td>{{task.last_runtime}}</td>
             <td>
-                <a class="crm-weight-arrow" style="cursor: pointer;" ng-click="moveTaskInList(task.id, 'top')">
-                    <img src="{{resourceBaseUrl}}i/arrow/first.gif" href="javascript:;" title="Move to top" alt="{{ts('Move to top')}}" class="order-icon">
-                </a>&nbsp;
-                <a class="crm-weight-arrow" style="cursor: pointer;" ng-click="moveTaskInList(task.id, 'up')">
-                    <img src="{{resourceBaseUrl}}i/arrow/up.gif" href="javascript:;" title="{{ts('Move up one row')}}" alt="Move up one row" class="order-icon">
-                </a>&nbsp;
-                <a class="crm-weight-arrow" style="cursor: pointer;" ng-click="moveTaskInList(task.id, 'down')">
-                    <img src="{{resourceBaseUrl}}i/arrow/down.gif" href="javascript:;" title="{{ts('Move down one row')}}" alt="Move down one row" class="order-icon">
-                </a>&nbsp;
-                <a class="crm-weight-arrow" style="cursor: pointer;" ng-click="moveTaskInList(task.id, 'bottom')">
-                    <img src="{{resourceBaseUrl}}i/arrow/last.gif" href="javascript:;" title="{{ts('Move to bottom')}}" alt="Move to bottom" class="order-icon">
-                </a>
+                <div class="sql-task-move-arrow-wrap">
+                    <a class="crm-weight-arrow sql-task-move-arrow crm-hover-button" ng-click="moveTaskInList(task.id, 'top')">
+                        <img src="{{resourceBaseUrl}}i/arrow/first.gif" href="javascript:;" title="Move to top" alt="{{ts('Move to top')}}">
+                    </a>
+                    <a class="crm-weight-arrow sql-task-move-arrow crm-hover-button" ng-click="moveTaskInList(task.id, 'up')">
+                        <img src="{{resourceBaseUrl}}i/arrow/up.gif" href="javascript:;" title="{{ts('Move up one row')}}" alt="Move up one row">
+                    </a>
+                    <a class="crm-weight-arrow sql-task-move-arrow crm-hover-button" ng-click="moveTaskInList(task.id, 'down')">
+                        <img src="{{resourceBaseUrl}}i/arrow/down.gif" href="javascript:;" title="{{ts('Move down one row')}}" alt="Move down one row">
+                    </a>
+                    <a class="crm-weight-arrow sql-task-move-arrow crm-hover-button" ng-click="moveTaskInList(task.id, 'bottom')">
+                        <img src="{{resourceBaseUrl}}i/arrow/last.gif" href="javascript:;" title="{{ts('Move to bottom')}}" alt="Move to bottom">
+                    </a>
+                </div>
             </td>
             <td>
                 <span class="btn-slide crm-hover-button" ng-click="showPanelForTaskId(task.id)">
                     {{ts('Actions', {'domain' : 'de.systopia.sqltasks'})}}
                     <ul ng-if="taskIdWithOpenPanel == task.id" class="panel">
-                        <li>
-                            <a ng-if="!getNumberFromString(task.input_required)"  class="action-item crm-hover-button"
-                               href="javascript:;" title="{{ts('Confirm')}}"
-                               crm-confirm="{title: ts('Run this task?'), width: '40%', message: ts('Are you sure you want to run this task?')}" on-yes="confirmRunTask(task.id)">
-                              {{ts('Run Now', {'domain' : 'de.systopia.sqltasks'})}}
+                        <li ng-if="!getNumberFromString(task.is_archived)" >
+                            <a ng-if="!getNumberFromString(task.input_required)" class="action-item crm-hover-button" href="javascript:;" title="{{ts('Confirm')}}"
+                                crm-confirm="{title: ts('Run this task?'), width: '40%', message: ts('Are you sure you want to run this task?')}" on-yes="confirmRunTask(task.id)">
+                                {{ts('Run Now', {'domain' : 'de.systopia.sqltasks'})}}
                             </a>
-                            <a ng-if="getNumberFromString(task.input_required)"  class="action-item crm-hover-button"
-                               href="javascript:;" title="{{ts('Confirm')}}"
-                               crm-confirm="{title: ts('Run this task?'), templateUrl: '~/sqlTaskManager/dialogWithInputVariable.html', width: '40%', export: {ts:ts, foo: '3333'}}"
-                               on-yes="confirmRunTaskWithInputVariable(task.id)">
-                              {{ts('Run Now', {'domain' : 'de.systopia.sqltasks'})}}
+                            <a ng-if="getNumberFromString(task.input_required)"  class="action-item crm-hover-button" href="javascript:;" title="{{ts('Confirm')}}"
+                                crm-confirm="{title: ts('Run this task?'), templateUrl: '~/sqlTaskManager/dialogWithInputVariable.html', width: '40%', export: {ts:ts, foo: '3333'}}"
+                                on-yes="confirmRunTaskWithInputVariable(task.id)">
+                                {{ts('Run Now', {'domain' : 'de.systopia.sqltasks'})}}
                             </a>
                         </li>
                         <li>
                             <a ng-href="#/sqltasks/configure/{{task.id}}"
                                 class="action-item crm-hover-button small-popup"
-                                title="{{ts('Configure', {'domain' : 'de.systopia.sqltasks'})}}">{{ts('Configure', {'domain' : 'de.systopia.sqltasks'})}}</a>
+                                title="{{ts('Configure', {'domain' : 'de.systopia.sqltasks'})}}">
+                                {{ts(getNumberFromString(task.is_archived) ? 'Configure(only view)' : 'Configure', {'domain' : 'de.systopia.sqltasks'})}}
+                            </a>
                         </li>
-                        <li>
+                        <li ng-if="!getNumberFromString(task.is_archived)" >
                             <a ng-if="getNumberFromString(task.enabled)" ng-click="onToggleEnablePress(task.id, 0)"
                                 class="action-item crm-hover-button small-popup"
-                                title="{{ts('Disable for scheduled execution', {'domain' : 'de.systopia.sqltasks'})}}">{{ts('Disable', {'domain' : 'de.systopia.sqltasks'})}}</a>
+                                title="{{ts('Disable for scheduled execution', {'domain' : 'de.systopia.sqltasks'})}}">
+                                {{ts('Disable', {'domain' : 'de.systopia.sqltasks'})}}
+                            </a>
                             <a ng-if="!getNumberFromString(task.enabled)" ng-click="onToggleEnablePress(task.id, 1)"
                                 class="action-item crm-hover-button small-popup"
-                                title="{{ts('Enable for scheduled execution', {'domain' : 'de.systopia.sqltasks'})}}">{{ts('Enable', {'domain' : 'de.systopia.sqltasks'})}}</a>
+                                title="{{ts('Enable for scheduled execution', {'domain' : 'de.systopia.sqltasks'})}}">
+                                {{ts('Enable', {'domain' : 'de.systopia.sqltasks'})}}
+                            </a>
                         </li>
                         <li>
                             <a ng-click="onDeletePress(task.id)" class="action-item crm-hover-button small-popup"
-                                title="{{ts('Delete Task', {'domain' : 'de.systopia.sqltasks'})}}">{{ts('Delete', {'domain' : 'de.systopia.sqltasks'})}}</a>
+                                title="{{ts('Delete Task', {'domain' : 'de.systopia.sqltasks'})}}">
+                                {{ts('Delete', {'domain' : 'de.systopia.sqltasks'})}}
+                            </a>
+                        </li>
+                        <li ng-if="!getNumberFromString(task.is_archived)" >
+                            <a ng-click="onArchivePress(task.id)" class="action-item crm-hover-button small-popup"
+                                title="{{ts('Archive', {'domain' : 'de.systopia.sqltasks'})}}">
+                                {{ts('Archive', {'domain' : 'de.systopia.sqltasks'})}}
+                            </a>
+                        </li>
+                        <li ng-if="getNumberFromString(task.is_archived)" >
+                            <a ng-click="onUnarchivePress(task.id)" class="action-item crm-hover-button small-popup"
+                                title="{{ts('Unarchive task', {'domain' : 'de.systopia.sqltasks'})}}">
+                                {{ts('Unarchive', {'domain' : 'de.systopia.sqltasks'})}}
+                            </a>
                         </li>
                         <li>
                             <a ng-href="/civicrm/sqltasks/export?id={{task.id}}"
                                 class="action-item crm-hover-button small-popup"
-                                title="{{ts('Export Configuration', {'domain' : 'de.systopia.sqltasks'})}}">{{ts('Export Config', {'domain' : 'de.systopia.sqltasks'})}}</a>
+                                title="{{ts('Export Configuration', {'domain' : 'de.systopia.sqltasks'})}}">
+                                {{ts('Export Config', {'domain' : 'de.systopia.sqltasks'})}}
+                            </a>
                         </li>
-                        <li>
+                        <li ng-if="!getNumberFromString(task.is_archived)" >
                             <a ng-href="#/sqltasks/import/{{task.id}}"
                                 class="action-item crm-hover-button small-popup"
-                                title="{{ts('Import Configuration', {'domain' : 'de.systopia.sqltasks'})}}">{{ts('Import Config', {'domain' : 'de.systopia.sqltasks'})}}</a>
+                                title="{{ts('Import Configuration', {'domain' : 'de.systopia.sqltasks'})}}">
+                                {{ts('Import Config', {'domain' : 'de.systopia.sqltasks'})}}
+                            </a>
                         </li>
                     </ul>
                 </span>

--- a/ang/taskRunner.js
+++ b/ang/taskRunner.js
@@ -38,16 +38,23 @@
         task_id: taskId,
         input_val: inputValue === undefined ? 0 : inputValue,
       }).done(function(result) {
-        if (result.values.log !== undefined && Array.isArray(result.values.log)) {
-          $scope.resultLogs = result.values.log;
-          $scope.isTaskReturnsEmptyLogs = $scope.resultLogs.length  === 0;
+        if (result.values && !result.is_error) {
+          if (result.values.log !== undefined && Array.isArray(result.values.log)) {
+            $scope.resultLogs = result.values.log;
+            $scope.isTaskReturnsEmptyLogs = $scope.resultLogs.length  === 0;
+          } else {
+            $scope.isTaskReturnsEmptyLogs = true;
+          }
+          $scope.isTaskRunning = false;
+          $scope.isShowLogs = true;
+          CRM.alert("Task execution completed", "Task execution", 'success');
         } else {
-          $scope.isTaskReturnsEmptyLogs = true;
+          CRM.alert(result.error_message, ts("Error task execution"), "error");
+          $scope.resultLogs = [ts('Task returns error: ') + result.error_message];
+          $scope.isTaskRunning = false;
+          $scope.isShowLogs = true;
         }
-        $scope.isTaskRunning = false;
-        $scope.isShowLogs = true;
         $scope.$apply();
-        CRM.alert("Task execution completed", "Task execution", 'success');
       }).fail(function() {
         $scope.resultLogs = ["An unknown error occurred during task execution. Please check your server logs for details before proceeding."];
         $scope.isTaskRunning = false;

--- a/api/v3/Sqltask/Archive.php
+++ b/api/v3/Sqltask/Archive.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Archive the task
+ *
+ * @param $params
+ *
+ * @return array
+ */
+function civicrm_api3_sqltask_archive($params) {
+  $task = CRM_Sqltasks_Task::getTask($params['id']);
+  if (empty($task)) {
+    return civicrm_api3_create_error('Task(id=' . $params['id'] . ') does not exist.');
+  }
+
+  $task->archive();
+
+  return civicrm_api3_create_success($task->getPreparedTask());
+}
+
+/**
+ * This is used for documentation and validation.
+ *
+ * @param array $params description of fields supported by this API call
+ * @return void
+ * @see http://wiki.civicrm.org/confluence/display/CRMDOC/API+Architecture+Standards
+ */
+function _civicrm_api3_sqltask_archive_spec(&$params) {
+  $params['id'] = [
+    'name'         => 'id',
+    'api.required' => 1,
+    'type'         => CRM_Utils_Type::T_INT,
+    'title'        => 'Task ID',
+    'description'  => 'Unique task ID',
+  ];
+}

--- a/api/v3/Sqltask/Create.php
+++ b/api/v3/Sqltask/Create.php
@@ -60,6 +60,11 @@ function civicrm_api3_sqltask_create($params) {
     if (empty($task)) {
       return civicrm_api3_create_error('Task(id=' . $params['id'] . ') does not exist.');
     }
+
+    if ($task->isArchived()) {
+      return civicrm_api3_create_error('Task(id=' . $params['id'] . ') is archived. Can not update any fields. To update any fields please unarchive the task.');
+    }
+
     foreach ($taskParams as $name => $value) {
       $task->setAttribute($name, $value, TRUE);
     }

--- a/api/v3/Sqltask/Execute.php
+++ b/api/v3/Sqltask/Execute.php
@@ -19,6 +19,10 @@ function civicrm_api3_sqltask_execute($params) {
       return civicrm_api3_create_error('Task(id=' . $params['id'] . ') does not exist.');
     }
 
+    if ($task->isArchived()) {
+      return civicrm_api3_create_error('Task(id=' . $params['id'] . ') is archived. Can not execute Task.');
+    }
+
     if (empty($params['check_permissions']) || $task->allowedToRun()) {
       $timestamp = microtime(TRUE);
       $result = $task->execute($exec_params);

--- a/api/v3/Sqltask/Importconfig.php
+++ b/api/v3/Sqltask/Importconfig.php
@@ -14,6 +14,10 @@ function civicrm_api3_sqltask_importconfig($params) {
     return civicrm_api3_create_error('Task(id=' . $params['id'] . ') does not exist.');
   }
 
+  if ($task->isArchived()) {
+    return civicrm_api3_create_error('Task(id=' . $params['id'] . ') is archived. Can not import config.');
+  }
+
   if (!empty($params['import_json_data']) && is_array($params['import_json_data'])) {
     $data = CRM_Sqltasks_Config_Format::toLatest($params['import_json_data']);
     foreach ($data as $key => $value) {

--- a/api/v3/Sqltask/Sort.php
+++ b/api/v3/Sqltask/Sort.php
@@ -38,7 +38,7 @@ function civicrm_api3_sqltask_sort($params) {
       $tasksorderNew[$key] = $task[0];
     }
 
-    // check the difference between taskorder array from database and the taskorder array from the screen
+    // check the difference between task order array from database and the task order array from the screen
     if ($taskScreenOrder != $tasksorderDatabase) {
       return civicrm_api3_create_error('Task order can\'t be modified. Task order on database must be equal with entered task order.');
     }

--- a/api/v3/Sqltask/Unarchive.php
+++ b/api/v3/Sqltask/Unarchive.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Unarchive the task
+ *
+ * @param $params
+ *
+ * @return array
+ */
+function civicrm_api3_sqltask_unarchive($params) {
+  $task = CRM_Sqltasks_Task::getTask($params['id']);
+  if (empty($task)) {
+    return civicrm_api3_create_error('Task(id=' . $params['id'] . ') does not exist.');
+  }
+
+  $task->unarchive();
+
+  return civicrm_api3_create_success($task->getPreparedTask());
+}
+
+/**
+ * This is used for documentation and validation.
+ *
+ * @param array $params description of fields supported by this API call
+ * @return void
+ * @see http://wiki.civicrm.org/confluence/display/CRMDOC/API+Architecture+Standards
+ */
+function _civicrm_api3_sqltask_unarchive_spec(&$params) {
+  $params['id'] = [
+    'name' => 'id',
+    'api.required' => 1,
+    'type' => CRM_Utils_Type::T_INT,
+    'title' => 'Task ID',
+    'description' => 'Unique task ID',
+  ];
+}

--- a/css/sqlTaskManager.css
+++ b/css/sqlTaskManager.css
@@ -1,7 +1,33 @@
-.page-civicrm-a.page-civicrm-a table:not(.form-layout-compressed) .tasks-table tr.even-row:not(.disabled)  {
+.page-civicrm-a.page-civicrm-a table:not(.form-layout-compressed) .tasks-table tr.even-row.enabled  {
   background: #d3f5ac;
 }
 
-.page-civicrm-a.page-civicrm-a table:not(.form-layout-compressed) .tasks-table tr.odd-row:not(.disabled) {
+.page-civicrm-a.page-civicrm-a table:not(.form-layout-compressed) .tasks-table tr.odd-row.enabled {
   background: #e5f9d0;
+}
+
+.page-civicrm-a.page-civicrm-a table:not(.form-layout-compressed) .tasks-table tr.even-row.archived  {
+  background: #fcdebd;
+}
+
+.page-civicrm-a.page-civicrm-a table:not(.form-layout-compressed) .tasks-table tr.odd-row.archived {
+  background: #ffeedb;
+}
+
+.sql-task-archive-message {
+  font-weight: bold;
+}
+
+.sql-task-move-arrow {
+  cursor: pointer;
+  display: inline-block;
+  margin: 0;
+}
+
+.sql-task-move-arrow img {
+  height: 15px;
+  width: 10px;
+  padding: 5px;
+  margin: 0;
+  display: block;
 }

--- a/css/sqlTaskManager.css
+++ b/css/sqlTaskManager.css
@@ -15,7 +15,7 @@
 }
 
 .sql-task-archive-message {
-  font-weight: bold;
+  font-style: italic;
 }
 
 .sql-task-move-arrow {

--- a/css/taskRunner.css
+++ b/css/taskRunner.css
@@ -1,6 +1,7 @@
 .sql-task-runner-block {
   padding: 10px 10px 0 10px;
 }
+
 .crm-container .sql-task-runner-buttons.crm-submit-buttons button:disabled {
   background: #bfbfbf;
 }

--- a/sql/civicrm_sqltasks.sql
+++ b/sql/civicrm_sqltasks.sql
@@ -11,6 +11,8 @@ CREATE TABLE IF NOT EXISTS `civicrm_sqltasks`(
   `running_since`   datetime     COMMENT 'set while task is being executed',
   `run_permissions` varchar(256) COMMENT 'permissions required to run',
   `input_required`  tinyint NOT NULL DEFAULT 0 COMMENT 'should have a mandatory form field?',
+  `is_archived`     tinyint NOT NULL DEFAULT 0 COMMENT 'is task archived?',
+  `archive_date`    datetime NULL DEFAULT NULL COMMENT 'archive date',
   `last_runtime`    int unsigned COMMENT 'stores the runtime of the last execution in milliseconds',
   `parallel_exec`   tinyint NOT NULL DEFAULT 0 COMMENT 'should this task be executed in parallel?',
   `main_sql`        text         COMMENT 'main script (SQL)',

--- a/sql/civicrm_sqltasks.sql
+++ b/sql/civicrm_sqltasks.sql
@@ -11,7 +11,6 @@ CREATE TABLE IF NOT EXISTS `civicrm_sqltasks`(
   `running_since`   datetime     COMMENT 'set while task is being executed',
   `run_permissions` varchar(256) COMMENT 'permissions required to run',
   `input_required`  tinyint NOT NULL DEFAULT 0 COMMENT 'should have a mandatory form field?',
-  `is_archived`     tinyint NOT NULL DEFAULT 0 COMMENT 'is task archived?',
   `archive_date`    datetime NULL DEFAULT NULL COMMENT 'archive date',
   `last_runtime`    int unsigned COMMENT 'stores the runtime of the last execution in milliseconds',
   `parallel_exec`   tinyint NOT NULL DEFAULT 0 COMMENT 'should this task be executed in parallel?',


### PR DESCRIPTION
- Added ability to archive tasks in task's menu. 
- Archived tasks has brown background. Added 'archive date' which appears in  column with name:
![archived_task](https://user-images.githubusercontent.com/36959503/81822486-da854e80-953b-11ea-91da-0ca67662330f.png)
-  Non archived task's menu:
![enabled_task_list_of_actions](https://user-images.githubusercontent.com/36959503/81822570-f7218680-953b-11ea-9db7-f7c97f5742c9.png)
-  Archived task's menu:
![archived_task_list_of_actions](https://user-images.githubusercontent.com/36959503/81822599-0274b200-953c-11ea-8ec7-16acb5570553.png)
- On 'task configurator' form added message for archived task and made disabled 'save' button.
![archived_task_message](https://user-images.githubusercontent.com/36959503/81822915-5d0e0e00-953c-11ea-84e8-13157f76ee80.png)
- Added `is_archived` and `archive_date` columns to `civicrm_sqltasks` table. Made upgrade `0120`. Updated sql which installs `civicrm_sqltasks` table.
- Added API: `sqltask->archive`. The API sets `is_archived` = 1, `archive_date` = now, 'enabled' = 0(to prevent accidentally executing after unarchiving) 
- Added API: `sqltask->unarchive`. The API sets `is_archived` = `0`, `archive_date` = `NULL`.
(I decided make two new API to separate logic instead of adding this logic to  'Sqltask->create' API.)
- Added validation(which checks if entered task is archived) to : 
1. `Sqltask->create(update)` API
2. `Sqltask->importconfig` API
3. `Sqltask->execute` API
4.  `CRM_Sqltasks_Task->runDispatcher()` - Dispatcher, triggered by a scheduled Job
- Go 'run task' page -> click on 'run task'. If API returns error(is not the same like error logs). For example: you are trying to run archived task. Before you get  only popup with message  "Error task execution". Now you get more detailed error message in UI:
![run_taks_error_message](https://user-images.githubusercontent.com/36959503/81827826-d1977b80-9541-11ea-972e-36535fd68f91.png)
