### PR TITLE
GP-8757: Change character limit for 'name' column in 'civicrm_sqltasks' table

### DIFF
--- a/CRM/Sqltasks/Upgrader.php
+++ b/CRM/Sqltasks/Upgrader.php
@@ -243,7 +243,7 @@ class CRM_Sqltasks_Upgrader extends CRM_Sqltasks_Upgrader_Base {
   }
 
   /**
-   * Update 'name' column in 'civicrm_sqltasks' table if column does exist
+   * Update 'name' column in 'civicrm_sqltasks' table
    * Sets max length to 255
    *
    * @return bool
@@ -251,14 +251,11 @@ class CRM_Sqltasks_Upgrader extends CRM_Sqltasks_Upgrader_Base {
    */
   public function upgrade_0110() {
     $this->ctx->log->info('Change character limit(set 255) for \'name\' column in \'civicrm_sqltasks\' table.');
-    $isColumnExists = CRM_Core_DAO::singleValueQuery("SHOW COLUMNS FROM `civicrm_sqltasks` LIKE 'name'");
-    if ($isColumnExists) {
-      CRM_Core_DAO::executeQuery("ALTER TABLE `civicrm_sqltasks` CHANGE COLUMN `name` `name` varchar(255) COMMENT 'name of the task'");
+    CRM_Core_DAO::executeQuery("ALTER TABLE `civicrm_sqltasks` CHANGE COLUMN `name` `name` varchar(255) COMMENT 'name of the task'");
 
-      // update rebuild log tables
-      $logging = new CRM_Logging_Schema();
-      $logging->fixSchemaDifferences();
-    }
+    // update rebuild log tables
+    $logging = new CRM_Logging_Schema();
+    $logging->fixSchemaDifferences();
 
     return TRUE;
   }

--- a/CRM/Sqltasks/Upgrader.php
+++ b/CRM/Sqltasks/Upgrader.php
@@ -242,4 +242,25 @@ class CRM_Sqltasks_Upgrader extends CRM_Sqltasks_Upgrader_Base {
     return TRUE;
   }
 
+  /**
+   * Update 'name' column in 'civicrm_sqltasks' table if column does exist
+   * Sets max length to 255
+   *
+   * @return bool
+   * @throws \Exception
+   */
+  public function upgrade_0110() {
+    $this->ctx->log->info('Change character limit(set 255) for \'name\' column in \'civicrm_sqltasks\' table.');
+    $isColumnExists = CRM_Core_DAO::singleValueQuery("SHOW COLUMNS FROM `civicrm_sqltasks` LIKE 'name'");
+    if ($isColumnExists) {
+      CRM_Core_DAO::executeQuery("ALTER TABLE `civicrm_sqltasks` CHANGE COLUMN `name` `name` varchar(255) COMMENT 'name of the task'");
+
+      // update rebuild log tables
+      $logging = new CRM_Logging_Schema();
+      $logging->fixSchemaDifferences();
+    }
+
+    return TRUE;
+  }
+
 }

--- a/ang/sqlTaskConfigurator/sqlTaskConfigurator.html
+++ b/ang/sqlTaskConfigurator/sqlTaskConfigurator.html
@@ -22,7 +22,7 @@
                         </label>
                     </div>
                     <div class="content">
-                        <input class="huge crm-form-text required" ng-model="taskOptions.name" maxlength="64" name="name" type="text" id="name" required>
+                        <input class="huge crm-form-text required" ng-model="taskOptions.name" maxlength="255" name="name" type="text" id="name" required>
                     </div>
                     <div class="clear"></div>
                 </div>

--- a/sql/civicrm_sqltasks.sql
+++ b/sql/civicrm_sqltasks.sql
@@ -1,7 +1,7 @@
 -- CREATE civicrm_sqltasks TABLE
 CREATE TABLE IF NOT EXISTS `civicrm_sqltasks`(
   `id`              int unsigned NOT NULL AUTO_INCREMENT,
-  `name`            varchar(64)  COMMENT 'name of the task',
+  `name`            varchar(255) COMMENT 'name of the task',
   `description`     text         COMMENT 'task description',
   `category`        varchar(64)  COMMENT 'task category',
   `scheduled`       varchar(256) COMMENT 'scheduling information',


### PR DESCRIPTION
- Changed character limit(64  => 255) for `name` column in `civicrm_sqltasks` table. Made `upgrade 0110`. Updated sql which installs `civicrm_sqltasks` table.
- Changed character limit(64  => 255) for `name` in `Task configurator` form. 
