### PR TITLE
GP-8323: As default archived tasks is hide.

### DIFF
--- a/CRM/Sqltasks/Task.php
+++ b/CRM/Sqltasks/Task.php
@@ -468,6 +468,39 @@ class CRM_Sqltasks_Task {
   }
 
   /**
+   * Get list of ordered tasks ids
+   *
+   * @return array
+   */
+  public static function getOrderedTasks() {
+    $result = CRM_Core_DAO::executeQuery('SELECT id FROM civicrm_sqltasks ORDER BY weight ASC, id ASC');
+    $tasksOrder = [];
+
+    while ($result->fetch()) {
+      $tasksOrder[] = $result->id;
+    }
+
+    return $tasksOrder;
+  }
+
+  /**
+   * Update order of tasks
+   *
+   * @param $newTasksOrder
+   */
+  public static function updateTasksOrder($newTasksOrder) {
+    foreach ($newTasksOrder as $key => $taskId) {
+      CRM_Core_DAO::executeQuery(
+        'UPDATE civicrm_sqltasks SET weight = %1 WHERE id = %2',
+        [
+          1 => [($key * 10) + 10, 'String'],
+          2 => [$taskId, 'Integer'],
+        ]
+      );
+    }
+  }
+
+  /**
    * Get a list of all SQL Task categories
    *
    * @return array

--- a/CRM/Sqltasks/Task.php
+++ b/CRM/Sqltasks/Task.php
@@ -868,7 +868,7 @@ class CRM_Sqltasks_Task {
       'next_execution' => 'TODO',
       'enabled'        => (empty($this->getAttribute('enabled'))) ? 0 : 1,
       'config'         => $this->getConfiguration(),
-      'is_archived'    => $this->isArchived(),
+      'is_archived'    => (int) $this->isArchived(),
       'archive_date'   => (empty($this->getAttribute('archive_date'))) ? '' : $this->getAttribute('archive_date'),
     ];
 

--- a/ang/sqlTaskManager.js
+++ b/ang/sqlTaskManager.js
@@ -22,12 +22,36 @@
     .module(moduleName)
     .controller("sqlTaskManagerCtrl", function($scope, $location, highlightTaskId, $timeout) {
       $scope.taskIdWithOpenPanel = null;
-      $scope.showPanelForTaskId = function(taskId) {
-        $scope.taskIdWithOpenPanel = taskId;
-      };
+      $scope.tasks = [];
+      $scope.displayTasks = [];
+      $scope.previousTaskOrder = [];
+      $scope.isTasksLoading = false;
+      $scope.getBooleanFromNumber = function(number) {return !!Number(number);};
+      $scope.getNumberFromString = function(stringValue) {return Number(stringValue);};
+      $scope.showPanelForTaskId = function(taskId) {$scope.taskIdWithOpenPanel = taskId;};
       $scope.ts = CRM.ts();
       $scope.dispatcher_frequency = null;
       $scope.resourceBaseUrl = CRM.config.resourceBase;
+      $scope.tasksDisplayPreferences = {
+        'isShowArchivedTask' : '0',
+        'isShowEnabledTask' : '1',
+        'isShowDisabledTask' : '1',
+      };
+
+      getAllTasks();
+      getCurrentDispatcherFrequency();
+
+      function getAllTasks() {
+        $scope.isTasksLoading = true;
+        CRM.api3("Sqltask", "getalltasks").done(function(result) {
+          $scope.tasks = result.values;
+          $scope.redrawTaskList();
+          $scope.updatePreviousTaskOrder();
+          $scope.$apply();
+          $timeout(function() {$scope.handleHighlightTask(highlightTaskId);}, 1000);
+          $scope.isTasksLoading = false;
+        });
+      }
 
       $scope.handleHighlightTask = function(taskId) {
         if (!taskId) {
@@ -41,30 +65,84 @@
         }
       };
 
-      getAllTasks();
-      getCurrentDispatcherFrequency();
+      $scope.getDisplayedTasks = function() {
+        return $scope.tasks.filter(function(task) {
+          if ($scope.tasksDisplayPreferences.isShowArchivedTask === '1' && task.is_archived === 1) {
+            return true;
+          }
+
+          if ($scope.tasksDisplayPreferences.isShowEnabledTask === '1' && task.enabled === 1) {
+            return true;
+          }
+
+          if (!($scope.tasksDisplayPreferences.isShowArchivedTask === '1')) {
+            if ($scope.tasksDisplayPreferences.isShowDisabledTask === '1' && task.enabled === 0 && task.is_archived !== 1) {
+              return true;
+            }
+          } else if ($scope.tasksDisplayPreferences.isShowDisabledTask === '1' && task.enabled === 0) {
+            return true;
+          }
+
+          return false;
+        });
+      };
+
+      $scope.redrawTaskList = function() {
+        $scope.displayTasks = $scope.getDisplayedTasks();
+      };
+
+      $scope.updateTaskData = function(taskId, taskData) {
+        var indexTasks = $scope.tasks.findIndex(task => task.id === taskId);
+        $scope.tasks[indexTasks] = taskData;
+        $scope.redrawTaskList();
+        $scope.$apply();
+      };
+
+      $scope.updatePreviousTaskOrder = function() {
+        $scope.previousTaskOrder = $scope.displayTasks.map(task => task.id);
+      };
+
+      $scope.updateAllTasksOrder = function(movedTaskId, moveToTaskId) {
+        var firstTaskIndex = $scope.tasks.findIndex(task => task.id === movedTaskId);
+        var secondTaskIndex = $scope.tasks.findIndex(task => task.id === moveToTaskId);
+        var firstTask = $scope.tasks[firstTaskIndex];
+        $scope.tasks.splice(firstTaskIndex, 1);
+        $scope.tasks.splice(secondTaskIndex, 0, firstTask);
+      };
+
+      $scope.updateDisplayTasksAfterMoving = function(movedTaskId, moveToTaskId) {
+        var firstTaskIndex = $scope.displayTasks.findIndex(task => task.id === movedTaskId);
+        var secondTaskIndex = $scope.displayTasks.findIndex(task => task.id === moveToTaskId);
+        var firstTask = $scope.displayTasks[firstTaskIndex];
+        $scope.displayTasks.splice(firstTaskIndex, 1);
+        $scope.displayTasks.splice(secondTaskIndex, 0, firstTask);
+      };
+
+      $scope.applySortingTasks = function(movedTaskId, moveToTaskId) {
+        if (movedTaskId === moveToTaskId) {
+          return;
+        }
+
+        var beforeSortTaskOrder = $scope.tasks.map(task => task.id);
+        $scope.updateAllTasksOrder(movedTaskId, moveToTaskId);
+
+        CRM.api3("Sqltask", "sort", {
+          after_sort_tasks_order: $scope.tasks.map(task => task.id),
+          before_sort_tasks_order: beforeSortTaskOrder
+        }).done(function(result) {
+          if (result.is_error) {
+            CRM.alert(ts("Error sorting tasks. Refresh the page and try again."), ts("Error"), "error");
+          }
+        });
+      };
 
       $scope.sortableOptions = {
         handle: ".handle-drag",
-        update: function() {
-          const oldOrder = $scope.tasks.map(task => {
-            return task.id;
-          });
-          $scope.oldOrder = oldOrder;
-          $scope.$apply();
-        },
-        stop: function() {
-          const newOrder = $scope.tasks.map(task => {
-            return task.id;
-          });
-          CRM.api3("Sqltask", "sort", {
-            data: newOrder,
-            task_screen_order: $scope.oldOrder
-          }).done(function(result) {
-            if (result.is_error) {
-              CRM.alert(ts("Error sorting tasks."), ts("Error"), "error");
-            }
-          });
+        update: $scope.updatePreviousTaskOrder,
+        stop: function(event, helper) {
+          var movedTaskId = helper.item.context.getAttribute("data-task-id");
+          var moveToTaskId = $scope.previousTaskOrder[$scope.displayTasks.findIndex(task => task.id === movedTaskId)];
+          $scope.applySortingTasks(movedTaskId, moveToTaskId);
         }
       };
 
@@ -83,93 +161,54 @@
         $location.path("/sqltasks/run/" + taskId);
       };
 
-      $scope.moveTaskInList = function(taskId, value) {
-        var index = $scope.tasks.findIndex(el => el.id === taskId);
-        var arrayOfIds = [];
-        $scope.tasks.forEach(task => arrayOfIds.push(task.id));
-        if (index !== -1 && arrayOfIds.length) {
-          var newOrder = swapElementsByAction(value, arrayOfIds, index);
-          if (newOrder !== null) {
-            CRM.api3("Sqltask", "sort", {
-              data: newOrder,
-              task_screen_order: arrayOfIds
-            }).done(function(result) {
-              if (result.values && !result.is_error) {
-                $scope.tasks = swapElementsByAction(value, $scope.tasks, index);
-                $scope.$apply();
-              } else {
-                CRM.alert(
-                  ts("Error changing tasks order."),
-                  ts("Error"),
-                  "error"
-                );
-              }
-            });
-          }
+      $scope.moveTaskInList = function(movedTaskId, direction) {
+        var movedTaskIndex = $scope.displayTasks.findIndex(task => task.id === movedTaskId);
+        var moveToTaskId;
+        var moveToTaskIndex;
+
+        switch (direction) {
+          case "up":
+            moveToTaskIndex = movedTaskIndex - 1;
+            if (moveToTaskIndex === -1) {
+              break;
+            }
+            moveToTaskId = $scope.displayTasks[moveToTaskIndex].id;
+            $scope.updateDisplayTasksAfterMoving(movedTaskId, moveToTaskId);
+            $scope.applySortingTasks(movedTaskId, moveToTaskId);
+            break;
+          case "down":
+            moveToTaskIndex = movedTaskIndex + 1;
+            if ($scope.displayTasks[moveToTaskIndex] === undefined) {
+              break;
+            }
+            moveToTaskId = $scope.displayTasks[moveToTaskIndex].id;
+            $scope.updateDisplayTasksAfterMoving(movedTaskId, moveToTaskId);
+            $scope.applySortingTasks(movedTaskId, moveToTaskId);
+            break;
+          case "top":
+            moveToTaskId = $scope.displayTasks[0].id;
+            $scope.updateDisplayTasksAfterMoving(movedTaskId, moveToTaskId);
+            $scope.applySortingTasks(movedTaskId, moveToTaskId);
+            break;
+          case "bottom":
+            moveToTaskId = $scope.displayTasks[$scope.displayTasks.length - 1].id;
+            $scope.updateDisplayTasksAfterMoving(movedTaskId, moveToTaskId);
+            $scope.applySortingTasks(movedTaskId, moveToTaskId);
+            break;
+          default:
         }
+        $scope.updatePreviousTaskOrder();
       };
 
-      $scope.getBooleanFromNumber = getBooleanFromNumber;
-
-      function getBooleanFromNumber(number) {
-        return !!Number(number);
-      }
-
-      function swapElementsByAction(action, initialArray, index) {
-        var array = initialArray.slice();
-        var newIndex = getNewIndexByAction(action, index, array);
-        if (newIndex !== null) {
-          if (action === "up" || action === "down") {
-            if (array[newIndex] === undefined) {
-              return null;
-            }
-            var tmp = array[newIndex];
-            array[newIndex] = array[index];
-            array[index] = tmp;
-          } else if (action === "bottom" || action === "top") {
-            var cuttedElement = array.splice(index, 1);
-            if (action === "bottom" && cuttedElement.length > 0) {
-              array.push(cuttedElement[0]);
-            } else if (action === "top" && cuttedElement.length > 0) {
-              array.unshift(cuttedElement[0]);
-            }
-          }
-        }
-        return array;
-      }
-
-      function getNewIndexByAction(action, index, lastElementIndex) {
-        switch (action) {
-          case "up":
-            return index - 1;
-          case "down":
-            return index + 1;
-          case "top":
-            return 0;
-          case "bottom":
-            return lastElementIndex - 1;
-          default:
-            return null;
-        }
-      }
-
       $scope.onToggleEnablePress = function(taskId, value) {
-        var index = $scope.tasks.findIndex(el => el.id === taskId);
-        var isEnabling = value == 1;
-        if (index === -1) {
-          CRM.alert(ts("Can't find task index. You can refresh page and try it again."), ts("Error enabling/disabling task"), "error");
-          return;
-        }
-
         CRM.api3("Sqltask", "create", {
           id: taskId,
           enabled: value
         }).done(function(result) {
+          var isEnabling = value === 1;
           if (result.values && !result.is_error) {
-            var successMessageTitle = (isEnabling ? 'Enabling' : 'Disabling') + ' task';
-            CRM.alert(ts('Task has successfully ' + (isEnabling ? 'enabled' : 'disabled')), ts(successMessageTitle), "success");
-            $scope.tasks[index] = result.values;
-            $scope.$apply();
+            CRM.alert(ts('Task has successfully ' + (isEnabling ? 'enabled' : 'disabled')), ts((isEnabling ? 'Enabling' : 'Disabling') + ' task'), "success");
+            $scope.updateTaskData(taskId, result.values);
           } else {
             CRM.alert(result.error_message, ts('Error ' + (isEnabling ? 'enabling' : 'disabling' + ' task'), "error"));
           }
@@ -177,17 +216,10 @@
       };
 
       $scope.onUnarchivePress = function(taskId) {
-        var index = $scope.tasks.findIndex(el => el.id === taskId);
-        if (index === -1) {
-          CRM.alert(ts("Can't find task index. You can refresh page and try it again."), ts("Error unarchiving task"), "error");
-          return;
-        }
-
         CRM.api3("Sqltask", "unarchive", {id: taskId}).done(function(result) {
           if (result.values && !result.is_error) {
             CRM.alert(ts('Task was successfully unarchived'), ts("Unarchiving task"), "success");
-            $scope.tasks[index] = result.values;
-            $scope.$apply();
+            $scope.updateTaskData(taskId, result.values);
           } else {
             CRM.alert(result.error_message, ts("Error unarchiving task"), "error");
           }
@@ -195,17 +227,10 @@
       };
 
       $scope.onArchivePress = function(taskId) {
-        var index = $scope.tasks.findIndex(el => el.id === taskId);
-        if (index === -1) {
-          CRM.alert(ts("Can't find task id. You can refresh page and try it again."), ts("Error archiving task"), "error");
-          return;
-        }
-
         CRM.api3("Sqltask", "archive", {id: taskId}).done(function(result) {
           if (result.values && !result.is_error) {
             CRM.alert(ts('Task was successfully archived'), ts("Archiving task"), "success");
-            $scope.tasks[index] = result.values;
-            $scope.$apply();
+            $scope.updateTaskData(taskId, result.values);
           } else {
             CRM.alert(result.error_message, ts("Error archiving task"), "error");
           }
@@ -215,18 +240,6 @@
       $scope.onDeletePress = function(taskId) {
         $location.path("/sqltasks/delete/" + taskId);
       };
-
-      $scope.getNumberFromString = function(stringValue) {
-        return Number(stringValue);
-      };
-
-      function getAllTasks() {
-        CRM.api3("Sqltask", "getalltasks").done(function(result) {
-          $scope.tasks = result.values;
-          $scope.$apply();
-          $timeout(function() {$scope.handleHighlightTask(highlightTaskId);}, 1000);
-        });
-      }
 
       function getCurrentDispatcherFrequency() {
         CRM.api3("Job", "get", {
@@ -261,5 +274,6 @@
           }
         });
       }
+
     });
 })(angular, CRM.$, CRM._);

--- a/ang/sqlTaskManager.js
+++ b/ang/sqlTaskManager.js
@@ -138,6 +138,10 @@
 
       $scope.sortableOptions = {
         handle: ".handle-drag",
+        placeholder: 'sql-task-target-highlight-place',
+        revert: 300,
+        cursor: "move",
+        scroll: true,
         update: $scope.updatePreviousTaskOrder,
         stop: function(event, helper) {
           var movedTaskId = helper.item.context.getAttribute("data-task-id");

--- a/ang/sqlTaskManager.js
+++ b/ang/sqlTaskManager.js
@@ -67,19 +67,19 @@
 
       $scope.getDisplayedTasks = function() {
         return $scope.tasks.filter(function(task) {
-          if ($scope.tasksDisplayPreferences.isShowArchivedTask === '1' && task.is_archived === 1) {
+          if ($scope.tasksDisplayPreferences.isShowArchivedTask === '1' && task.is_archived == 1) {
             return true;
           }
 
-          if ($scope.tasksDisplayPreferences.isShowEnabledTask === '1' && task.enabled === 1) {
+          if ($scope.tasksDisplayPreferences.isShowEnabledTask === '1' && task.enabled == 1) {
             return true;
           }
 
           if (!($scope.tasksDisplayPreferences.isShowArchivedTask === '1')) {
-            if ($scope.tasksDisplayPreferences.isShowDisabledTask === '1' && task.enabled === 0 && task.is_archived !== 1) {
+            if ($scope.tasksDisplayPreferences.isShowDisabledTask === '1' && task.enabled == 0 && task.is_archived != 1) {
               return true;
             }
-          } else if ($scope.tasksDisplayPreferences.isShowDisabledTask === '1' && task.enabled === 0) {
+          } else if ($scope.tasksDisplayPreferences.isShowDisabledTask === '1' && task.enabled == 0) {
             return true;
           }
 
@@ -138,7 +138,7 @@
 
       $scope.sortableOptions = {
         handle: ".handle-drag",
-        placeholder: 'sql-task-target-highlight-place',
+        placeholder: 'sql-task-manager-target-highlight-place',
         revert: 300,
         cursor: "move",
         scroll: true,

--- a/ang/sqlTaskManager.js
+++ b/ang/sqlTaskManager.js
@@ -125,6 +125,7 @@
 
         var beforeSortTaskOrder = $scope.tasks.map(task => task.id);
         $scope.updateAllTasksOrder(movedTaskId, moveToTaskId);
+        $scope.updatePreviousTaskOrder();
 
         CRM.api3("Sqltask", "sort", {
           after_sort_tasks_order: $scope.tasks.map(task => task.id),

--- a/ang/sqlTaskManager/sqlTaskManager.html
+++ b/ang/sqlTaskManager/sqlTaskManager.html
@@ -60,13 +60,16 @@
 
   <div class="sql-task-manager-preference-wrap">
     <div class="crm-accordion-wrapper collapsed">
-      <div class="crm-accordion-header">{{ts('Tasks display preferences')}}</div>
+      <div class="crm-accordion-header">{{ts('Display Preferences')}}</div>
       <div class="crm-accordion-body">
 
         <div class="sql-task-preference-item">
+          Display tasks that are:
+        </div>
+        <div class="sql-task-preference-item">
           <label class="sql-task-preference-item-label" for="isShowEnabledTask">
             <span class="sql-task-preference-item-color enabled"></span>
-            <span class="sql-task-preference-item-label-text">{{ts('Is show enabled task?')}}</span>
+            <span class="sql-task-preference-item-label-text">{{ts('Enabled')}}</span>
           </label>
           <input class="sql-task-preference-item-input crm-form-checkbox" ng-true-value="'1'" ng-false-value="'0'"
             ng-change="redrawTaskList(); updatePreviousTaskOrder();"
@@ -76,7 +79,7 @@
         <div class="sql-task-preference-item">
           <label class="sql-task-preference-item-label" for="isShowDisabledTask">
             <span class="sql-task-preference-item-color disabled"></span>
-            <span class="sql-task-preference-item-label-text">{{ts('Is show disabled task?')}}</span>
+            <span class="sql-task-preference-item-label-text">{{ts('Disabled')}}</span>
           </label>
           <input class="sql-task-preference-item-input crm-form-checkbox" ng-true-value="'1'" ng-false-value="'0'"
             ng-change="redrawTaskList(); updatePreviousTaskOrder();"
@@ -86,7 +89,7 @@
         <div class="sql-task-preference-item">
           <label class="sql-task-preference-item-label" for="isShowArchivedTask">
             <span class="sql-task-preference-item-color archived"></span>
-            <span class="sql-task-preference-item-label-text">{{ts('Is show archived task?')}}</span>
+            <span class="sql-task-preference-item-label-text">{{ts('Archived')}}</span>
           </label>
           <input class="sql-task-preference-item-input crm-form-checkbox" ng-true-value="'1'" ng-false-value="'0'"
             ng-change="redrawTaskList(); updatePreviousTaskOrder();"
@@ -244,5 +247,4 @@
       <i>{{ts('can potentially destroy your database')}}</i>.
       {{ts('Only use this if you really know what you\'re doing, and always keep a backup of your database before experimenting.', {'domain' : 'de.systopia.sqltasks'})}}
   </div>
->>>>>>> acf7173... GP-8323: Refactor 'SqlTask->sort' api. Add 'diplay perferences' block. Add preloader to page. Update 'drag and drop' and moving by arrows functionality. Refactor.
 </div>

--- a/ang/sqlTaskManager/sqlTaskManager.html
+++ b/ang/sqlTaskManager/sqlTaskManager.html
@@ -151,18 +151,18 @@
               </td>
               <td>{{task.last_runtime}}</td>
               <td>
-                  <div class="sql-task-table-column-last-moving-arrows">
-                      <a class="crm-weight-arrow" style="cursor: pointer;" ng-click="moveTaskInList(task.id, 'top')">
-                          <img src="{{resourceBaseUrl}}i/arrow/first.gif" href="javascript:;" title="Move to top" alt="{{ts('Move to top')}}" class="order-icon">
+                  <div class="sql-task-move-arrow-wrap">
+                      <a class="crm-weight-arrow sql-task-move-arrow crm-hover-button" ng-click="moveTaskInList(task.id, 'top')">
+                          <img src="{{resourceBaseUrl}}i/arrow/first.gif" href="javascript:;" title="Move to top" alt="{{ts('Move to top')}}">
                       </a>
-                      <a class="crm-weight-arrow" style="cursor: pointer;" ng-click="moveTaskInList(task.id, 'up')">
-                          <img src="{{resourceBaseUrl}}i/arrow/up.gif" href="javascript:;" title="{{ts('Move up one row')}}" alt="Move up one row" class="order-icon">
+                      <a class="crm-weight-arrow sql-task-move-arrow crm-hover-button" ng-click="moveTaskInList(task.id, 'up')">
+                          <img src="{{resourceBaseUrl}}i/arrow/up.gif" href="javascript:;" title="{{ts('Move up one row')}}" alt="Move up one row">
                       </a>
-                      <a class="crm-weight-arrow" style="cursor: pointer;" ng-click="moveTaskInList(task.id, 'down')">
-                          <img src="{{resourceBaseUrl}}i/arrow/down.gif" href="javascript:;" title="{{ts('Move down one row')}}" alt="Move down one row" class="order-icon">
+                      <a class="crm-weight-arrow sql-task-move-arrow crm-hover-button" ng-click="moveTaskInList(task.id, 'down')">
+                          <img src="{{resourceBaseUrl}}i/arrow/down.gif" href="javascript:;" title="{{ts('Move down one row')}}" alt="Move down one row">
                       </a>
-                      <a class="crm-weight-arrow" style="cursor: pointer;" ng-click="moveTaskInList(task.id, 'bottom')">
-                          <img src="{{resourceBaseUrl}}i/arrow/last.gif" href="javascript:;" title="{{ts('Move to bottom')}}" alt="Move to bottom" class="order-icon">
+                      <a class="crm-weight-arrow sql-task-move-arrow crm-hover-button" ng-click="moveTaskInList(task.id, 'bottom')">
+                          <img src="{{resourceBaseUrl}}i/arrow/last.gif" href="javascript:;" title="{{ts('Move to bottom')}}" alt="Move to bottom">
                       </a>
                   </div>
               </td>

--- a/ang/sqlTaskManager/sqlTaskManager.html
+++ b/ang/sqlTaskManager/sqlTaskManager.html
@@ -102,7 +102,7 @@
 
   <div class="sql-task-info-panel">
     <div class="sql-task-info-display-counter">
-      <span>{{ts('Displayed %1 of %2 tasks.', { '1' : displayTasks.length, '2' : tasks.length})}}</span>
+      <span>{{ts('Displaying %1 of %2 tasks.', { '1' : displayTasks.length, '2' : tasks.length})}}</span>
     </div>
   </div>
   <table class="display">

--- a/ang/sqlTaskManager/sqlTaskManager.html
+++ b/ang/sqlTaskManager/sqlTaskManager.html
@@ -1,190 +1,248 @@
 <h1 crm-page-title>{{ts('SQL Task Manager')}}</h1>
 
-<div class="help">
-    <div ng-switch on="tasks.length > 0">
-        <div ng-switch-when="true">
-            {{ts('This is the list of currently configured tasks.', {'domain' : 'de.systopia.sqltasks'})}}
-        </div>
-        <div ng-switch-default>
-            {{ts('It looks like you\'re new here. This is the control center for all you SQL based scheduled tasks, but there is no task configured yet.', {'domain' : 'de.systopia.sqltasks'})}}
-        </div>
-    </div>
-    <div>
-        {{ts('You might want to')}} <a ng-href="#/sqltasks/configure/0">{{ts('ADD A NEW ONE')}}</a>.
-        {{ts('Check out our')}}
-        <a href="https://github.com/systopia/de.systopia.sqltasks/blob/master/tasks/readme.md" target="_blank">{{ts('REPOSITORY')}}</a>
-          {{ts('for examples to get you started.')}}
-        </a>
-    </div>
-</div>
-<br />
 
-<div class="help">
-    <div ng-switch on="dispatcher_frequency">
-        <div ng-switch-when="Daily">
-            {{ts('The dispatcher is run')}}
-            <strong>{{ts('every day')}}</strong>
-            {{ts('after midnight. This is effectively the maximum frequency these tasks are being executed with.')}}
-        </div>
-        <div ng-switch-when="Hourly">
-            {{ts('The dispatcher is run')}}
-            <strong>{{ts('every hour')}}</strong>
-            {{ts('on the hour. This is effectively the maximum frequency these tasks are being executed with.')}}
-        </div>
-        <div ng-switch-when="Always">
-            {{ts('The dispatcher (and therefore all active tasks) will be triggered')}}
-            <strong>{{ts('with every cron-run')}}</strong>.
-            {{ts('Ask your administrator how often that is, in order to know the effective maximum frequency these tasks are being executed with.')}}
-        </div>
-        <div ng-switch-default>
-            {{ts('The dispatcher is currently')}}
-            <strong>{{ts('disabled')}}</strong>,
-            {{ts('none of the tasks will be executed automatically.')}}
-        </div>
+<div ng-if="isTasksLoading" class="sql-task-manager-preloader-block">
+  <div class="sql-task-manager-preloader-message">{{ts('Please wait, tasks is loading ...')}}</div>
+  <div class="sql-task-manager-preloader">
+    <div class="crm-container">
+      <div class="dataTables_processing"></div>
     </div>
+  </div>
 </div>
 
-<br />
+<div class="sql-task-manager-page" ng-if="!isTasksLoading">
+  <div class="help">
+      <div ng-switch on="tasks.length > 0">
+          <div ng-switch-when="true">
+              {{ts('This is the list of currently configured tasks.', {'domain' : 'de.systopia.sqltasks'})}}
+          </div>
+          <div ng-switch-default>
+              {{ts('It looks like you\'re new here. This is the control center for all you SQL based scheduled tasks, but there is no task configured yet.', {'domain' : 'de.systopia.sqltasks'})}}
+          </div>
+      </div>
+      <div>
+          {{ts('You might want to')}} <a ng-href="#/sqltasks/configure/0">{{ts('ADD A NEW ONE')}}</a>.
+          {{ts('Check out our')}}
+          <a href="https://github.com/systopia/de.systopia.sqltasks/blob/master/tasks/readme.md" target="_blank">{{ts('REPOSITORY')}}</a>
+            {{ts('for examples to get you started.')}}
+          </a>
+      </div>
+  </div>
 
-<table class="display">
-    <thead>
-        <tr>
-            <th class="sorting_disabled" rowspan="1" colspan="1">{{ts('Category')}}</th>
-            <th class="sorting_disabled" rowspan="1" colspan="1">{{ts('ID')}}</th>
-            <th class="sorting_disabled" rowspan="1" colspan="1">{{ts('Name')}}</th>
-            <th class="sorting_disabled" rowspan="1" colspan="1">{{ts('Description')}}</th>
-            <th class="sorting_disabled" rowspan="1" colspan="1">{{ts('Enabled?')}}</th>
-            <th class="sorting_disabled" rowspan="1" colspan="1">{{ts('Schedule')}}</th>
-            <th class="sorting_disabled" rowspan="1" colspan="1">{{ts('Last Execution')}}</th>
-            <th class="sorting_disabled" rowspan="1" colspan="1">{{ts('Last Runtime')}}</th>
-            <th class="sorting_disabled" rowspan="1" colspan="1">{{ts('Selection Order')}}</th>
-            <th class="sorting_disabled" rowspan="1" colspan="1"></th>
-            <th class="sorting_disabled" rowspan="1" colspan="1"></th>
-        </tr>
-    </thead>
-    <tbody ui-sortable="sortableOptions" id="sortable-tasks" class="ui-sortable tasks-table" ng-model="tasks">
-        <tr ng-repeat="task in tasks" id="{{task.id}}" data-task-id="{{task.id}}" class="sql-task-row-item"
-            ng-class="{enabled : getNumberFromString(task.enabled), disabled : !getNumberFromString(task.enabled), 'odd-row': $odd, 'even-row': $even, archived: getNumberFromString(task.is_archived)}">
-            <td>
-                <div class="sql-task-table-column-category">
-                   {{task.category}}
-                </div>
-            </td>
-            <td>[{{task.id}}]</td>
-            <td>
-                <div class="sql-task-table-column-name">{{task.name}}</div>
-                <div ng-if="getNumberFromString(task.is_archived)" class="sql-task-archive-message">{{ts('Archived at %1', { '1' : task.archive_date})}}</div>
-            </td>
-            <td>
-                <div class="sql-task-table-column-description" title="{{task.description}}">
-                    {{task.short_desc}}
-                </div>
-            </td>
-            <td>{{getNumberFromString(task.enabled) ? 'Yes' : 'No'}}</td>
-            <td>
-                <span>{{task.schedule_label}}</span>
-                <span ng-if="getBooleanFromNumber(task.parallel_exec)"><strong>{{ts('(parallel)')}}</strong></span>
-            </td>
-            <td>
-                <div class="sql-task-table-column-last-executed">
-                    {{task.last_executed}}
-                </div>
-            </td>
-            <td>{{task.last_runtime}}</td>
-            <td>
-                <div class="sql-task-table-column-last-moving-arrows">
-                    <a class="crm-weight-arrow" style="cursor: pointer;" ng-click="moveTaskInList(task.id, 'top')">
-                        <img src="{{resourceBaseUrl}}i/arrow/first.gif" href="javascript:;" title="Move to top" alt="{{ts('Move to top')}}" class="order-icon">
-                    </a>
-                    <a class="crm-weight-arrow" style="cursor: pointer;" ng-click="moveTaskInList(task.id, 'up')">
-                        <img src="{{resourceBaseUrl}}i/arrow/up.gif" href="javascript:;" title="{{ts('Move up one row')}}" alt="Move up one row" class="order-icon">
-                    </a>
-                    <a class="crm-weight-arrow" style="cursor: pointer;" ng-click="moveTaskInList(task.id, 'down')">
-                        <img src="{{resourceBaseUrl}}i/arrow/down.gif" href="javascript:;" title="{{ts('Move down one row')}}" alt="Move down one row" class="order-icon">
-                    </a>
-                    <a class="crm-weight-arrow" style="cursor: pointer;" ng-click="moveTaskInList(task.id, 'bottom')">
-                        <img src="{{resourceBaseUrl}}i/arrow/last.gif" href="javascript:;" title="{{ts('Move to bottom')}}" alt="Move to bottom" class="order-icon">
-                    </a>
-                </div>
-            </td>
-            <td>
-                <span class="btn-slide crm-hover-button" ng-click="showPanelForTaskId(task.id)">
-                    {{ts('Actions', {'domain' : 'de.systopia.sqltasks'})}}
-                    <ul ng-if="taskIdWithOpenPanel == task.id" class="panel">
-                        <li ng-if="!getNumberFromString(task.is_archived)" >
-                            <a ng-if="!getNumberFromString(task.input_required)" class="action-item crm-hover-button" href="javascript:;" title="{{ts('Confirm')}}"
-                                crm-confirm="{title: ts('Run this task?'), width: '40%', message: ts('Are you sure you want to run this task?')}" on-yes="confirmRunTask(task.id)">
-                                {{ts('Run Now', {'domain' : 'de.systopia.sqltasks'})}}
-                            </a>
-                            <a ng-if="getNumberFromString(task.input_required)"  class="action-item crm-hover-button" href="javascript:;" title="{{ts('Confirm')}}"
-                                crm-confirm="{title: ts('Run this task?'), templateUrl: '~/sqlTaskManager/dialogWithInputVariable.html', width: '40%', export: {ts:ts, foo: '3333'}}"
-                                on-yes="confirmRunTaskWithInputVariable(task.id)">
-                                {{ts('Run Now', {'domain' : 'de.systopia.sqltasks'})}}
-                            </a>
-                        </li>
-                        <li>
-                            <a ng-href="#/sqltasks/configure/{{task.id}}"
-                                class="action-item crm-hover-button small-popup"
-                                title="{{ts('Configure', {'domain' : 'de.systopia.sqltasks'})}}">
-                                {{ts(getNumberFromString(task.is_archived) ? 'Configure (read-only)' : 'Configure', {'domain' : 'de.systopia.sqltasks'})}}
-                            </a>
-                        </li>
-                        <li ng-if="!getNumberFromString(task.is_archived)" >
-                            <a ng-if="getNumberFromString(task.enabled)" ng-click="onToggleEnablePress(task.id, 0)"
-                                class="action-item crm-hover-button small-popup"
-                                title="{{ts('Disable for scheduled execution', {'domain' : 'de.systopia.sqltasks'})}}">
-                                {{ts('Disable', {'domain' : 'de.systopia.sqltasks'})}}
-                            </a>
-                            <a ng-if="!getNumberFromString(task.enabled)" ng-click="onToggleEnablePress(task.id, 1)"
-                                class="action-item crm-hover-button small-popup"
-                                title="{{ts('Enable for scheduled execution', {'domain' : 'de.systopia.sqltasks'})}}">
-                                {{ts('Enable', {'domain' : 'de.systopia.sqltasks'})}}
-                            </a>
-                        </li>
-                        <li>
-                            <a ng-click="onDeletePress(task.id)" class="action-item crm-hover-button small-popup"
-                                title="{{ts('Delete Task', {'domain' : 'de.systopia.sqltasks'})}}">
-                                {{ts('Delete', {'domain' : 'de.systopia.sqltasks'})}}
-                            </a>
-                        </li>
-                        <li ng-if="!getNumberFromString(task.is_archived) && !getNumberFromString(task.enabled)" >
-                            <a ng-click="onArchivePress(task.id)" class="action-item crm-hover-button small-popup"
-                                title="{{ts('Archive', {'domain' : 'de.systopia.sqltasks'})}}">
-                                {{ts('Archive', {'domain' : 'de.systopia.sqltasks'})}}
-                            </a>
-                        </li>
-                        <li ng-if="getNumberFromString(task.is_archived)" >
-                            <a ng-click="onUnarchivePress(task.id)" class="action-item crm-hover-button small-popup"
-                                title="{{ts('Unarchive task', {'domain' : 'de.systopia.sqltasks'})}}">
-                                {{ts('Unarchive', {'domain' : 'de.systopia.sqltasks'})}}
-                            </a>
-                        </li>
-                        <li>
-                            <a ng-href="/civicrm/sqltasks/export?id={{task.id}}"
-                                class="action-item crm-hover-button small-popup"
-                                title="{{ts('Export Configuration', {'domain' : 'de.systopia.sqltasks'})}}">
-                                {{ts('Export Config', {'domain' : 'de.systopia.sqltasks'})}}
-                            </a>
-                        </li>
-                        <li ng-if="!getNumberFromString(task.is_archived)" >
-                            <a ng-href="#/sqltasks/import/{{task.id}}"
-                                class="action-item crm-hover-button small-popup"
-                                title="{{ts('Import Configuration', {'domain' : 'de.systopia.sqltasks'})}}">
-                                {{ts('Import Config', {'domain' : 'de.systopia.sqltasks'})}}
-                            </a>
-                        </li>
-                    </ul>
-                </span>
-            </td>
-            <td class="handle-drag" style="cursor: move;">
-                <div>&#8693;</div>
-            </td>
-        </tr>
-    </tbody>
-</table>
-<br />
-<div class="help">
-    <strong>{{ts('Caution!')}}</strong> {{ts('Be aware that these tasks can execute arbitrary SQL statements, which')}}
-    <i>{{ts('can potentially destroy your database')}}</i>.
-    {{ts('Only use this if you really know what you\'re doing, and always keep a backup of your database before experimenting.', {'domain' : 'de.systopia.sqltasks'})}}
+  <br />
+
+  <div class="help">
+      <div ng-switch on="dispatcher_frequency">
+          <div ng-switch-when="Daily">
+              {{ts('The dispatcher is run')}}
+              <strong>{{ts('every day')}}</strong>
+              {{ts('after midnight. This is effectively the maximum frequency these tasks are being executed with.')}}
+          </div>
+          <div ng-switch-when="Hourly">
+              {{ts('The dispatcher is run')}}
+              <strong>{{ts('every hour')}}</strong>
+              {{ts('on the hour. This is effectively the maximum frequency these tasks are being executed with.')}}
+          </div>
+          <div ng-switch-when="Always">
+              {{ts('The dispatcher (and therefore all active tasks) will be triggered')}}
+              <strong>{{ts('with every cron-run')}}</strong>.
+              {{ts('Ask your administrator how often that is, in order to know the effective maximum frequency these tasks are being executed with.')}}
+          </div>
+          <div ng-switch-default>
+              {{ts('The dispatcher is currently')}}
+              <strong>{{ts('disabled')}}</strong>,
+              {{ts('none of the tasks will be executed automatically.')}}
+          </div>
+      </div>
+  </div>
+
+  <br />
+
+  <div class="sql-task-manager-preference-wrap">
+    <div class="crm-accordion-wrapper collapsed">
+      <div class="crm-accordion-header">{{ts('Tasks display preferences')}}</div>
+      <div class="crm-accordion-body">
+
+        <div class="sql-task-preference-item">
+          <label class="sql-task-preference-item-label" for="isShowEnabledTask">
+            <span class="sql-task-preference-item-color enabled"></span>
+            <span class="sql-task-preference-item-label-text">{{ts('Is show enabled task?')}}</span>
+          </label>
+          <input class="sql-task-preference-item-input crm-form-checkbox" ng-true-value="'1'" ng-false-value="'0'"
+            ng-change="redrawTaskList(); updatePreviousTaskOrder();"
+            ng-model="tasksDisplayPreferences.isShowEnabledTask" id="isShowEnabledTask" name="isShowEnabledTask" type="checkbox" >
+        </div>
+
+        <div class="sql-task-preference-item">
+          <label class="sql-task-preference-item-label" for="isShowDisabledTask">
+            <span class="sql-task-preference-item-color disabled"></span>
+            <span class="sql-task-preference-item-label-text">{{ts('Is show disabled task?')}}</span>
+          </label>
+          <input class="sql-task-preference-item-input crm-form-checkbox" ng-true-value="'1'" ng-false-value="'0'"
+            ng-change="redrawTaskList(); updatePreviousTaskOrder();"
+            ng-model="tasksDisplayPreferences.isShowDisabledTask" id="isShowDisabledTask" name="isShowDisabledTask" type="checkbox" >
+        </div>
+
+        <div class="sql-task-preference-item">
+          <label class="sql-task-preference-item-label" for="isShowArchivedTask">
+            <span class="sql-task-preference-item-color archived"></span>
+            <span class="sql-task-preference-item-label-text">{{ts('Is show archived task?')}}</span>
+          </label>
+          <input class="sql-task-preference-item-input crm-form-checkbox" ng-true-value="'1'" ng-false-value="'0'"
+            ng-change="redrawTaskList(); updatePreviousTaskOrder();"
+            ng-model="tasksDisplayPreferences.isShowArchivedTask" id="isShowArchivedTask" name="isShowArchivedTask" type="checkbox" >
+        </div>
+
+      </div>
+    </div>
+  </div>
+
+  <div class="sql-task-info-panel">
+    <div class="sql-task-info-display-counter">
+      <span>{{ts('Displayed %1 of %2 tasks.', { '1' : displayTasks.length, '2' : tasks.length})}}</span>
+    </div>
+  </div>
+  <table class="display">
+      <thead>
+          <tr>
+              <th class="sorting_disabled" rowspan="1" colspan="1">{{ts('Category')}}</th>
+              <th class="sorting_disabled" rowspan="1" colspan="1">{{ts('ID')}}</th>
+              <th class="sorting_disabled" rowspan="1" colspan="1">{{ts('Name')}}</th>
+              <th class="sorting_disabled" rowspan="1" colspan="1">{{ts('Description')}}</th>
+              <th class="sorting_disabled" rowspan="1" colspan="1">{{ts('Enabled?')}}</th>
+              <th class="sorting_disabled" rowspan="1" colspan="1">{{ts('Schedule')}}</th>
+              <th class="sorting_disabled" rowspan="1" colspan="1">{{ts('Last Execution')}}</th>
+              <th class="sorting_disabled" rowspan="1" colspan="1">{{ts('Last Runtime')}}</th>
+              <th class="sorting_disabled" rowspan="1" colspan="1">{{ts('Selection Order')}}</th>
+              <th class="sorting_disabled" rowspan="1" colspan="1"></th>
+              <th class="sorting_disabled" rowspan="1" colspan="1"></th>
+          </tr>
+      </thead>
+      <tbody ui-sortable="sortableOptions" id="sortable-tasks" class="ui-sortable tasks-table" ng-model="displayTasks">
+          <tr ng-repeat="task in displayTasks" id="{{task.id}}" data-task-id="{{task.id}}" class="sql-task-row-item"
+              ng-class="{enabled : getNumberFromString(task.enabled), disabled : !getNumberFromString(task.enabled), 'odd-row': $odd, 'even-row': $even, archived: getNumberFromString(task.is_archived)}">
+              <td>
+                  <div class="sql-task-table-column-category">
+                      {{task.category}}
+                  </div>
+              </td>
+              <td>[{{task.id}}]</td>
+              <td>
+                  <div class="sql-task-table-column-name">{{task.name}}</div>
+                  <div ng-if="getNumberFromString(task.is_archived)" class="sql-task-archive-message">{{ts('Archived at %1', { '1' : task.archive_date})}}</div>
+              </td>
+              <td>
+                  <div class="sql-task-table-column-description" title="{{task.description}}">
+                      {{task.short_desc}}
+                  </div>
+              </td>
+              <td>{{getNumberFromString(task.enabled) ? 'Yes' : 'No'}}</td>
+              <td>
+                  <span>{{task.schedule_label}}</span>
+                  <span ng-if="getBooleanFromNumber(task.parallel_exec)"><strong>{{ts('(parallel)')}}</strong></span>
+              </td>
+              <td>
+                  <div class="sql-task-table-column-last-executed">
+                      {{task.last_executed}}
+                  </div>
+              </td>
+              <td>{{task.last_runtime}}</td>
+              <td>
+                  <div class="sql-task-table-column-last-moving-arrows">
+                      <a class="crm-weight-arrow" style="cursor: pointer;" ng-click="moveTaskInList(task.id, 'top')">
+                          <img src="{{resourceBaseUrl}}i/arrow/first.gif" href="javascript:;" title="Move to top" alt="{{ts('Move to top')}}" class="order-icon">
+                      </a>
+                      <a class="crm-weight-arrow" style="cursor: pointer;" ng-click="moveTaskInList(task.id, 'up')">
+                          <img src="{{resourceBaseUrl}}i/arrow/up.gif" href="javascript:;" title="{{ts('Move up one row')}}" alt="Move up one row" class="order-icon">
+                      </a>
+                      <a class="crm-weight-arrow" style="cursor: pointer;" ng-click="moveTaskInList(task.id, 'down')">
+                          <img src="{{resourceBaseUrl}}i/arrow/down.gif" href="javascript:;" title="{{ts('Move down one row')}}" alt="Move down one row" class="order-icon">
+                      </a>
+                      <a class="crm-weight-arrow" style="cursor: pointer;" ng-click="moveTaskInList(task.id, 'bottom')">
+                          <img src="{{resourceBaseUrl}}i/arrow/last.gif" href="javascript:;" title="{{ts('Move to bottom')}}" alt="Move to bottom" class="order-icon">
+                      </a>
+                  </div>
+              </td>
+              <td>
+                  <span class="btn-slide crm-hover-button" ng-click="showPanelForTaskId(task.id)">
+                      {{ts('Actions', {'domain' : 'de.systopia.sqltasks'})}}
+                      <ul ng-if="taskIdWithOpenPanel == task.id" class="panel">
+                          <li ng-if="!getNumberFromString(task.is_archived)" >
+                              <a ng-if="!getNumberFromString(task.input_required)" class="action-item crm-hover-button" href="javascript:;" title="{{ts('Confirm')}}"
+                                  crm-confirm="{title: ts('Run this task?'), width: '40%', message: ts('Are you sure you want to run this task?')}" on-yes="confirmRunTask(task.id)">
+                                  {{ts('Run Now', {'domain' : 'de.systopia.sqltasks'})}}
+                              </a>
+                              <a ng-if="getNumberFromString(task.input_required)"  class="action-item crm-hover-button" href="javascript:;" title="{{ts('Confirm')}}"
+                                  crm-confirm="{title: ts('Run this task?'), templateUrl: '~/sqlTaskManager/dialogWithInputVariable.html', width: '40%', export: {ts:ts, foo: '3333'}}"
+                                  on-yes="confirmRunTaskWithInputVariable(task.id)">
+                                  {{ts('Run Now', {'domain' : 'de.systopia.sqltasks'})}}
+                              </a>
+                          </li>
+                          <li>
+                              <a ng-href="#/sqltasks/configure/{{task.id}}"
+                                  class="action-item crm-hover-button small-popup"
+                                  title="{{ts('Configure', {'domain' : 'de.systopia.sqltasks'})}}">
+                                  {{ts(getNumberFromString(task.is_archived) ? 'Configure (read-only)' : 'Configure', {'domain' : 'de.systopia.sqltasks'})}}
+                              </a>
+                          </li>
+                          <li ng-if="!getNumberFromString(task.is_archived)" >
+                              <a ng-if="getNumberFromString(task.enabled)" ng-click="onToggleEnablePress(task.id, 0)"
+                                  class="action-item crm-hover-button small-popup"
+                                  title="{{ts('Disable for scheduled execution', {'domain' : 'de.systopia.sqltasks'})}}">
+                                  {{ts('Disable', {'domain' : 'de.systopia.sqltasks'})}}
+                              </a>
+                              <a ng-if="!getNumberFromString(task.enabled)" ng-click="onToggleEnablePress(task.id, 1)"
+                                  class="action-item crm-hover-button small-popup"
+                                  title="{{ts('Enable for scheduled execution', {'domain' : 'de.systopia.sqltasks'})}}">
+                                  {{ts('Enable', {'domain' : 'de.systopia.sqltasks'})}}
+                              </a>
+                          </li>
+                          <li>
+                              <a ng-click="onDeletePress(task.id)" class="action-item crm-hover-button small-popup"
+                                  title="{{ts('Delete Task', {'domain' : 'de.systopia.sqltasks'})}}">
+                                  {{ts('Delete', {'domain' : 'de.systopia.sqltasks'})}}
+                              </a>
+                          </li>
+                          <li ng-if="!getNumberFromString(task.is_archived) && !getNumberFromString(task.enabled)" >
+                              <a ng-click="onArchivePress(task.id)" class="action-item crm-hover-button small-popup"
+                                  title="{{ts('Archive', {'domain' : 'de.systopia.sqltasks'})}}">
+                                  {{ts('Archive', {'domain' : 'de.systopia.sqltasks'})}}
+                              </a>
+                          </li>
+                          <li ng-if="getNumberFromString(task.is_archived)" >
+                              <a ng-click="onUnarchivePress(task.id)" class="action-item crm-hover-button small-popup"
+                                  title="{{ts('Unarchive task', {'domain' : 'de.systopia.sqltasks'})}}">
+                                  {{ts('Unarchive', {'domain' : 'de.systopia.sqltasks'})}}
+                              </a>
+                          </li>
+                          <li>
+                              <a ng-href="/civicrm/sqltasks/export?id={{task.id}}"
+                                  class="action-item crm-hover-button small-popup"
+                                  title="{{ts('Export Configuration', {'domain' : 'de.systopia.sqltasks'})}}">
+                                  {{ts('Export Config', {'domain' : 'de.systopia.sqltasks'})}}
+                              </a>
+                          </li>
+                          <li ng-if="!getNumberFromString(task.is_archived)" >
+                              <a ng-href="#/sqltasks/import/{{task.id}}"
+                                  class="action-item crm-hover-button small-popup"
+                                  title="{{ts('Import Configuration', {'domain' : 'de.systopia.sqltasks'})}}">
+                                  {{ts('Import Config', {'domain' : 'de.systopia.sqltasks'})}}
+                              </a>
+                          </li>
+                      </ul>
+                  </span>
+              </td>
+              <td class="handle-drag" style="cursor: move;">
+                  <div>&#8693;</div>
+              </td>
+          </tr>
+      </tbody>
+  </table>
+  <br />
+  <div class="help">
+      <strong>{{ts('Caution!')}}</strong> {{ts('Be aware that these tasks can execute arbitrary SQL statements, which')}}
+      <i>{{ts('can potentially destroy your database')}}</i>.
+      {{ts('Only use this if you really know what you\'re doing, and always keep a backup of your database before experimenting.', {'domain' : 'de.systopia.sqltasks'})}}
+  </div>
+>>>>>>> acf7173... GP-8323: Refactor 'SqlTask->sort' api. Add 'diplay perferences' block. Add preloader to page. Update 'drag and drop' and moving by arrows functionality. Refactor.
 </div>

--- a/api/v3/Sqltask/Sort.php
+++ b/api/v3/Sqltask/Sort.php
@@ -1,89 +1,44 @@
 <?php
 
 /**
+ * Sets new order of all tasks
  * Sqltask.sort API
  *
- * Updates the order of the SQL Tasks
+ * @param $params
  *
- * @param array $params
  * @return array API result descriptor
- * @see civicrm_api3_create_success
- * @see civicrm_api3_create_error
- * @throws API_Exception
  */
 function civicrm_api3_sqltask_sort($params) {
-
-  try {
-    $tasksorderNew = $params['data'];
-    $taskScreenOrder = $params['task_screen_order'];
-
-    // create new taskorder array for comparison with old taskorder array
-    foreach ($taskScreenOrder as $key => $task) {
-      $task = explode('_', $task);
-      $taskScreenOrder[$key] = $task[0];
-    }
-
-    // fetch the task sorting from database
-    $query = "SELECT id FROM civicrm_sqltasks ORDER BY weight ASC, id ASC";
-    $result = CRM_Core_DAO::executeQuery($query);
-    $tasksorderDatabase = [];
-
-    while ($result->fetch()) {
-      $tasksorderDatabase[] = $result->id;
-    }
-
-    // create new taskorder array for comparison with old taskorder array
-    foreach ($tasksorderNew as $key => $task) {
-      $task = explode('_', $task);
-      $tasksorderNew[$key] = $task[0];
-    }
-
-    // check the difference between task order array from database and the task order array from the screen
-    if ($taskScreenOrder != $tasksorderDatabase) {
-      return civicrm_api3_create_error('Task order can\'t be modified. Task order on database must be equal with entered task order.');
-    }
-
-    foreach ($tasksorderNew as $key => $task) {
-      $weight = ($key * 10) + 10;
-      $query = "UPDATE civicrm_sqltasks SET weight = %1 WHERE id = %2";
-      $sqlParams = [
-        1 => [$weight, 'String'],
-        2 => [$task, 'Integer'],
-      ];
-
-      CRM_Core_DAO::executeQuery($query, $sqlParams);
-    }
-
-    return civicrm_api3_create_success(['Task order have successfully modified.']);
+  if ($params['before_sort_tasks_order'] != CRM_Sqltasks_Task::getOrderedTasks()) {
+    return civicrm_api3_create_error('Task order can\'t be modified. Task order on database must be equal with entered task order.');
   }
-  catch (Exception $e) {
-    return civicrm_api3_create_error($e->getMessage());
-  }
+
+  CRM_Sqltasks_Task::updateTasksOrder($params['after_sort_tasks_order']);
+
+  return civicrm_api3_create_success(['Task order have successfully modified.']);
 }
 
 /**
- * Sqltask.sort API specification (optional)
  * This is used for documentation and validation.
  *
  * @param array $params description of fields supported by this API call
- * @return void
+ *
  * @see http://wiki.civicrm.org/confluence/display/CRMDOC/API+Architecture+Standards
  */
 function _civicrm_api3_sqltask_sort_spec(&$params) {
-
-  $params['data'] = [
-    'name'         => 'data',
+  $params['after_sort_tasks_order'] = [
+    'name'         => 'after_sort_tasks_order',
     'api.required' => 1,
     'type'         => CRM_Utils_Type::T_STRING,
-    'title'        => 'New taskorder/weight data ',
-    'description'  => 'New taskorder for resorting and saving to database.',
+    'title'        => 'Task order after sort',
+    'description'  => 'It is list of tasks ids. That order will be saved to database.',
   ];
 
-  $params['task_screen_order'] = [
-    'name'         => 'task_screen_order',
+  $params['before_sort_tasks_order'] = [
+    'name'         => 'before_sort_tasks_order',
     'api.required' => 1,
     'type'         => CRM_Utils_Type::T_STRING,
-    'title'        => 'Old taskorder/weight data ',
-    'description'  => 'Screen taskorder for comparing with new taskorder.',
+    'title'        => 'Task order before sort',
+    'description'  => 'It is list of tasks ids. That order will be compared with order from database.',
   ];
 }

--- a/css/sqlTaskManager.css
+++ b/css/sqlTaskManager.css
@@ -54,7 +54,7 @@
 
 .sql-task-move-arrow-wrap {
   word-wrap: break-word;
-  max-width: 90px;
+  max-width: 120px;
 }
 
 .sql-task-preference-item {

--- a/css/sqlTaskManager.css
+++ b/css/sqlTaskManager.css
@@ -121,3 +121,8 @@
   padding: 10px;
   color: black;
 }
+
+.sql-task-target-highlight-place {
+  border: solid 4px #ffe59b !important;
+  height: 130px;
+}

--- a/css/sqlTaskManager.css
+++ b/css/sqlTaskManager.css
@@ -27,7 +27,7 @@
 .sql-task-move-arrow img {
   height: 15px;
   width: 10px;
-  padding: 5px;
+  padding: 2px;
   margin: 0;
   display: block;
 }
@@ -52,7 +52,7 @@
   max-width: 130px;
 }
 
-.sql-task-table-column-last-moving-arrows {
+.sql-task-move-arrow-wrap {
   word-wrap: break-word;
   max-width: 90px;
 }
@@ -122,7 +122,7 @@
   color: black;
 }
 
-.sql-task-target-highlight-place {
+.sql-task-manager-target-highlight-place {
   border: solid 4px #ffe59b !important;
   height: 130px;
 }

--- a/css/sqlTaskManager.css
+++ b/css/sqlTaskManager.css
@@ -56,3 +56,68 @@
   word-wrap: break-word;
   max-width: 90px;
 }
+
+.sql-task-preference-item {
+  display: inline-block;
+  padding: 10px 15px 10px 10px;
+}
+
+.sql-task-preference-item:first-child {
+  display: inline-block;
+  padding-left: 0;
+}
+
+.sql-task-preference-item-label {
+  display: inline-block;
+  vertical-align: middle;
+  padding-right: 2px;
+}
+
+.sql-task-preference-item-input {
+  display: inline-block;
+  vertical-align: middle;
+}
+
+.sql-task-preference-item-label-text {
+  display: inline-block;
+  vertical-align: middle;
+}
+
+.sql-task-preference-item-color {
+  background: white;
+  width: 15px;
+  height: 15px;
+  display: inline-block;
+  vertical-align: middle;
+}
+
+.sql-task-preference-item-color.archived {
+  background: #fcdebd;
+}
+
+.sql-task-preference-item-color.enabled {
+  background: #d3f5ac;
+}
+
+.sql-task-preference-item-color.disabled {
+  background: #EFEFEF;
+}
+
+.sql-task-info-display-counter {
+  padding: 10px;
+  display: inline-block;
+}
+
+.sql-task-info-panel {
+  padding: 10px;
+}
+
+.sql-task-manager-preloader {
+  position: relative;
+  height: 100px;
+}
+
+.sql-task-manager-preloader-message {
+  padding: 10px;
+  color: black;
+}


### PR DESCRIPTION
- Updated moving tasks by arrows. Now it can handle filtered list of tasks.
- Updated 'drag and drop' functionality. Now it can handle filtered list of tasks.
- Fixed issue: "Drag task and move it on the same position. After that it shows popup with error"
- Fixed issue: "Fast drag task and drop it. Do it  3-5 times. After that it shows popup with error."
- Added `Tasks display preferences` block:
![task_dispaly_preferences](https://user-images.githubusercontent.com/36959503/82910788-b67e3000-9f73-11ea-9e9c-d69a8e878c82.png)
There you can disable/enable preferences: 
1.To show archived tasks(as default disabled); 
2.To show enabled tasks; 
3.To show disabled tasks; 
As default block is collapsed:
![task_dispaly_preferences_hided](https://user-images.githubusercontent.com/36959503/82910874-d6adef00-9f73-11ea-8d98-1fcda14ad082.png)
Below added block which shows count of all tasks and  count of  displayed tasks.

- Added preloader to `task manger` page. It fixes issue. Previous behavior: before list of task is loaded you can see the message: `It looks like you\'re new here. This is the control center...`  Now that message will show only when you don't have any created tasks.

- Refactored `SqlTask->sort` API.

