### PR TITLE
GP-8446: Add UI to create sqltask global tokens.

### DIFF
--- a/CRM/Sqltasks/Action.php
+++ b/CRM/Sqltasks/Action.php
@@ -174,10 +174,7 @@ abstract class CRM_Sqltasks_Action {
           break;
 
         case 'config':
-          $config = Civi::settings()->get('sqltasks_global_tokens');
-          if (is_array($config) && array_key_exists($match['token'], $config)) {
-            $tokenValue = $config[$match['token']];
-          }
+          $tokenValue = (CRM_Sqltasks_GlobalToken::singleton())->getValue($match['token']);
           break;
       }
       $token = '{' . $match['prefix'] . '.' . $match['token'] . '}';

--- a/CRM/Sqltasks/GlobalToken.php
+++ b/CRM/Sqltasks/GlobalToken.php
@@ -1,0 +1,164 @@
+
+<?php
+
+/**
+ * This class is adapter which safely works with sqltasks global tokens
+ */
+class CRM_Sqltasks_GlobalToken {
+
+  /**
+   * Setting name in CiviCRM
+   * There located sqltasks global tokens
+   */
+  const SETTING_NAME = 'sqltasks_global_tokens';
+
+  /**
+   * Max length of token name
+   */
+  const MAX_LENGTH_OF_TOKEN_NAME = 60;
+
+  /**
+   * Instance
+   *
+   * @var CRM_Sqltasks_GlobalToken
+   */
+  private static $instance = null;
+
+  /**
+   * All tokens
+   *
+   * @var array
+   */
+  private $tokens;
+
+  /**
+   * Gets the instance
+   *
+   * @return CRM_Sqltasks_GlobalToken
+   */
+  public static function singleton() {
+    if (static::$instance === null) {
+      static::$instance = new static();
+    }
+
+    return static::$instance;
+  }
+
+  private function __construct() {
+    $this->tokens = $this->getTokensFromSettings();
+  }
+
+  /**
+   * Gets all tokens from CiviCRM Settings
+   *
+   * @return array
+   */
+  private function getTokensFromSettings() {
+    $tokens = Civi::settings()->get(self::SETTING_NAME);
+
+    return is_array($tokens) ? $tokens : [];
+  }
+
+  /**
+   * Gets token value
+   *
+   * @param $tokenName
+   * @return string
+   */
+  public function getValue($tokenName) {
+    if (!empty($tokenName) && array_key_exists($tokenName, $this->tokens)) {
+      return $this->tokens[$tokenName];
+    }
+
+    return '';
+  }
+
+  /**
+   * Sets value to token
+   * If token not exist it creates new one
+   * else it updates token's value
+   *
+   * @param $tokenName
+   * @param $tokenValue
+   */
+  public function setValue($tokenName, $tokenValue) {
+    if (empty($tokenName)) {
+      return;
+    }
+
+    if (is_numeric($tokenName)) {
+      $tokenName = (string) $tokenName;
+    }
+
+    $this->tokens[$tokenName] = $tokenValue;
+    $this->save();
+  }
+
+  /**
+   * Saves tokens into CiviCRM Settings
+   */
+  private function save() {
+    Civi::settings()->set(self::SETTING_NAME, $this->tokens);
+  }
+
+  /**
+   * Gets token data
+   *
+   * @param $tokenName
+   * @return array
+   */
+  public function getTokenData($tokenName) {
+    return [
+      'name' => $tokenName,
+      'value' => $this->getValue($tokenName),
+    ];
+  }
+
+  /**
+   * Gets all tokens data
+   *
+   * @return array
+   */
+  public function getAllTokenData() {
+    $tokensData = [];
+    foreach ($this->tokens as $tokenName => $tokenValue) {
+      $tokensData[] = $this->getTokenData($tokenName);
+    }
+
+    return $tokensData;
+  }
+
+  /**
+   * Is token exist?
+   *
+   * @param $tokenName
+   * @return mixed|string
+   */
+  public function isTokenExist($tokenName) {
+    return !empty($tokenName) && array_key_exists($tokenName, $this->tokens);
+  }
+
+  /**
+   * Delete token
+   *
+   * @param $tokenName
+   */
+  public function delete($tokenName) {
+    if (empty($tokenName)) {
+      return;
+    }
+
+    if (is_numeric($tokenName)) {
+      $tokenName = (string) $tokenName;
+    }
+
+    if ($this->isTokenExist($tokenName)) {
+      unset($this->tokens[$tokenName]);
+      $this->save();
+    }
+  }
+
+  private function __clone() {}
+  private function __wakeup() {}
+
+}

--- a/CRM/Sqltasks/GlobalToken.php
+++ b/CRM/Sqltasks/GlobalToken.php
@@ -135,6 +135,10 @@ class CRM_Sqltasks_GlobalToken {
    * @return mixed|string
    */
   public function isTokenExist($tokenName) {
+    if (is_numeric($tokenName)) {
+      $tokenName = (string) $tokenName;
+    }
+
     return !empty($tokenName) && array_key_exists($tokenName, $this->tokens);
   }
 

--- a/CRM/Sqltasks/GlobalToken.php
+++ b/CRM/Sqltasks/GlobalToken.php
@@ -66,6 +66,8 @@ class CRM_Sqltasks_GlobalToken {
    * @return string
    */
   public function getValue($tokenName) {
+    $tokenName = (string) $tokenName;
+
     if (!empty($tokenName) && array_key_exists($tokenName, $this->tokens)) {
       return $this->tokens[$tokenName];
     }
@@ -86,10 +88,7 @@ class CRM_Sqltasks_GlobalToken {
       return;
     }
 
-    if (is_numeric($tokenName)) {
-      $tokenName = (string) $tokenName;
-    }
-
+    $tokenName = (string) $tokenName;
     $this->tokens[$tokenName] = $tokenValue;
     $this->save();
   }
@@ -109,7 +108,7 @@ class CRM_Sqltasks_GlobalToken {
    */
   public function getTokenData($tokenName) {
     return [
-      'name' => $tokenName,
+      'name' => (string) $tokenName,
       'value' => $this->getValue($tokenName),
     ];
   }
@@ -135,9 +134,7 @@ class CRM_Sqltasks_GlobalToken {
    * @return mixed|string
    */
   public function isTokenExist($tokenName) {
-    if (is_numeric($tokenName)) {
-      $tokenName = (string) $tokenName;
-    }
+    $tokenName = (string) $tokenName;
 
     return !empty($tokenName) && array_key_exists($tokenName, $this->tokens);
   }
@@ -152,9 +149,7 @@ class CRM_Sqltasks_GlobalToken {
       return;
     }
 
-    if (is_numeric($tokenName)) {
-      $tokenName = (string) $tokenName;
-    }
+    $tokenName = (string) $tokenName;
 
     if ($this->isTokenExist($tokenName)) {
       unset($this->tokens[$tokenName]);

--- a/CRM/Sqltasks/Page/GlobalTokenManager.php
+++ b/CRM/Sqltasks/Page/GlobalTokenManager.php
@@ -5,7 +5,7 @@ use CRM_Sqltasks_ExtensionUtil as E;
 class CRM_Sqltasks_Page_GlobalTokenManager extends CRM_Core_Page {
 
   public function run() {
-    CRM_Utils_System::setTitle(E::ts("Global Token Manager"));
+    CRM_Utils_System::setTitle(E::ts("SQL Task Global Token Manager"));
 
     $this->assign('tokens', json_encode((CRM_Sqltasks_GlobalToken::singleton())->getAllTokenData()));
     $this->assign('maxLengthOfTokenName', CRM_Sqltasks_GlobalToken::MAX_LENGTH_OF_TOKEN_NAME);

--- a/CRM/Sqltasks/Page/GlobalTokenManager.php
+++ b/CRM/Sqltasks/Page/GlobalTokenManager.php
@@ -1,0 +1,16 @@
+<?php
+
+use CRM_Sqltasks_ExtensionUtil as E;
+
+class CRM_Sqltasks_Page_GlobalTokenManager extends CRM_Core_Page {
+
+  public function run() {
+    CRM_Utils_System::setTitle(E::ts("Global Token Manager"));
+
+    $this->assign('tokens', json_encode((CRM_Sqltasks_GlobalToken::singleton())->getAllTokenData()));
+    $this->assign('maxLengthOfTokenName', CRM_Sqltasks_GlobalToken::MAX_LENGTH_OF_TOKEN_NAME);
+
+    parent::run();
+  }
+
+}

--- a/ang/sqlTaskManager.js
+++ b/ang/sqlTaskManager.js
@@ -21,6 +21,7 @@
   angular
     .module(moduleName)
     .controller("sqlTaskManagerCtrl", function($scope, $location, highlightTaskId, $timeout) {
+      $scope.url = CRM.url;
       $scope.taskIdWithOpenPanel = null;
       $scope.showPanelForTaskId = function(taskId) {
         $scope.taskIdWithOpenPanel = taskId;

--- a/ang/sqlTaskManager/sqlTaskManager.html
+++ b/ang/sqlTaskManager/sqlTaskManager.html
@@ -10,6 +10,10 @@
         </div>
     </div>
     <div>
+      {{ts('You can manage tokens on')}}
+      <a href="{{url('civicrm/sqltasks/global-token-manager')}}">{{ts('Global Token Manager page')}}</a>
+    </div>
+    <div>
         {{ts('You might want to')}} <a ng-href="#/sqltasks/configure/0">{{ts('ADD A NEW ONE')}}</a>.
         {{ts('Check out our')}}
         <a href="https://github.com/systopia/de.systopia.sqltasks/blob/master/tasks/readme.md" target="_blank">{{ts('REPOSITORY')}}</a>

--- a/ang/sqlTaskManager/sqlTaskManager.html
+++ b/ang/sqlTaskManager/sqlTaskManager.html
@@ -20,15 +20,15 @@
           </div>
       </div>
       <div>
-        {{ts('You can manage tokens on')}}
-        <a href="{{url('civicrm/sqltasks/global-token-manager')}}">{{ts('Global Token Manager page')}}</a>
-      </div>
-      <div>
           {{ts('You might want to')}} <a ng-href="#/sqltasks/configure/0">{{ts('ADD A NEW ONE')}}</a>.
           {{ts('Check out our')}}
           <a href="https://github.com/systopia/de.systopia.sqltasks/blob/master/tasks/readme.md" target="_blank">{{ts('REPOSITORY')}}</a>
             {{ts('for examples to get you started.')}}
           </a>
+      </div>
+      <div>
+          {{ts('You can manage global tokens ')}}
+          <a href="{{url('civicrm/sqltasks/global-token-manager')}}">{{ts('here.')}}</a>
       </div>
   </div>
 

--- a/api/v3/SqltaskGlobalToken/Create.php
+++ b/api/v3/SqltaskGlobalToken/Create.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Creates new global token
+ *
+ * @param $params
+ *
+ * @return array
+ */
+function civicrm_api3_sqltask_global_token_create($params) {
+  $globalToken = CRM_Sqltasks_GlobalToken::singleton();
+
+  if ($globalToken->isTokenExist($params['name'])) {
+    return civicrm_api3_create_error(ts("Token name is already exists."));
+  }
+
+  if (!isset($params['value'])) {
+    $params['value'] = '';
+  }
+
+  if (strlen($params['name']) > CRM_Sqltasks_GlobalToken::MAX_LENGTH_OF_TOKEN_NAME) {
+    return civicrm_api3_create_error(ts("Max length of token name is %1", ['1' => CRM_Sqltasks_GlobalToken::MAX_LENGTH_OF_TOKEN_NAME] ));
+  }
+
+  $globalToken->setValue($params['name'], $params['value']);
+
+  return civicrm_api3_create_success([$globalToken->getTokenData($params['name'])]);
+}
+
+/**
+ * This is used for documentation and validation.
+ *
+ * @param array $params description of fields supported by this API call
+ * @return void
+ * @see http://wiki.civicrm.org/confluence/display/CRMDOC/API+Architecture+Standards
+ */
+function _civicrm_api3_sqltask_global_token_create_spec(&$params) {
+  $params['name'] = [
+    'name' => 'name',
+    'api.required' => 1,
+    'type' => CRM_Utils_Type::T_STRING,
+    'title' => 'Token name',
+    'description'  => 'The value of this name will be updated.',
+  ];
+
+  $params['value'] = [
+    'name' => 'value',
+    'api.required' => 0,
+    'type' => CRM_Utils_Type::T_STRING,
+    'title' => 'Token value',
+    'description'  => 'New token value.',
+  ];
+}

--- a/api/v3/SqltaskGlobalToken/DeleteToken.php
+++ b/api/v3/SqltaskGlobalToken/DeleteToken.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Deletes global token by name
+ *
+ * @param $params
+ *
+ * @return array
+ */
+function civicrm_api3_sqltask_global_token_delete_token($params) {
+  $globalToken = CRM_Sqltasks_GlobalToken::singleton();
+  $globalToken->delete($params['name']);
+
+  return civicrm_api3_create_success(['The token doesn\'t exist anymore.']);
+}
+
+/**
+ * This is used for documentation and validation.
+ *
+ * @param array $params description of fields supported by this API call
+ * @return void
+ * @see http://wiki.civicrm.org/confluence/display/CRMDOC/API+Architecture+Standards
+ */
+function _civicrm_api3_sqltask_global_token_delete_token_spec(&$params) {
+  $params['name'] = [
+    'name' => 'name',
+    'api.required' => 1,
+    'type' => CRM_Utils_Type::T_STRING,
+    'title' => 'Token name',
+    'description'  => 'This token will be deleted',
+  ];
+}

--- a/api/v3/SqltaskGlobalToken/Get.php
+++ b/api/v3/SqltaskGlobalToken/Get.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Gets sqltask token/tokens
+ *
+ * @param $params
+ *
+ * @return array
+ */
+function civicrm_api3_sqltask_global_token_get($params) {
+  $globalToken = CRM_Sqltasks_GlobalToken::singleton();
+
+  if (empty($params['name'])) {
+    return civicrm_api3_create_success($globalToken->getAllTokenData());
+  }
+
+  return civicrm_api3_create_success([$globalToken->getTokenData($params['name'])]);
+}
+
+/**
+ * This is used for documentation and validation.
+ *
+ * @param array $params description of fields supported by this API call
+ * @return void
+ * @see http://wiki.civicrm.org/confluence/display/CRMDOC/API+Architecture+Standards
+ */
+function _civicrm_api3_sqltask_global_token_get_spec(&$params) {
+  $params['name'] = [
+    'name' => 'name',
+    'api.required' => 0,
+    'type' => CRM_Utils_Type::T_STRING,
+    'title' => 'Token name',
+  ];
+}

--- a/api/v3/SqltaskGlobalToken/UpdateToken.php
+++ b/api/v3/SqltaskGlobalToken/UpdateToken.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * Update token data
+ *
+ * @param $params
+ *
+ * @return array
+ */
+function civicrm_api3_sqltask_global_token_update_token($params) {
+  $globalToken = CRM_Sqltasks_GlobalToken::singleton();
+
+  if (!$globalToken->isTokenExist($params['name'])) {
+    return civicrm_api3_create_error("This token with this name does not exist.");
+  }
+
+  if (!empty($params['new_name'])) {
+    if ($params['new_name'] != $params['name']) {
+      if ($globalToken->isTokenExist($params['new_name'])) {
+        return civicrm_api3_create_error(ts("Token name is already exists."));
+      }
+
+      if (strlen($params['new_name']) > CRM_Sqltasks_GlobalToken::MAX_LENGTH_OF_TOKEN_NAME) {
+        return civicrm_api3_create_error(ts("Max length of token name is %1", ['1' => CRM_Sqltasks_GlobalToken::MAX_LENGTH_OF_TOKEN_NAME] ));
+      }
+
+      $globalToken->delete($params['name']);
+    }
+
+    $globalToken->setValue($params['new_name'], $params['value']);
+
+    return civicrm_api3_create_success([$globalToken->getTokenData($params['new_name'])]);
+  }
+
+  $globalToken->setValue($params['name'], $params['value']);
+
+  return civicrm_api3_create_success([$globalToken->getTokenData($params['name'])]);
+}
+
+/**
+ * This is used for documentation and validation.
+ *
+ * @param array $params description of fields supported by this API call
+ * @return void
+ * @see http://wiki.civicrm.org/confluence/display/CRMDOC/API+Architecture+Standards
+ */
+function _civicrm_api3_sqltask_global_token_update_token_spec(&$params) {
+  $params['name'] = [
+    'name' => 'name',
+    'api.required' => 1,
+    'type' => CRM_Utils_Type::T_STRING,
+    'title' => 'Token name',
+    'description'  => 'Token which will be updated',
+  ];
+
+  $params['new_name'] = [
+    'name' => 'new_name',
+    'api.required' => 0,
+    'type' => CRM_Utils_Type::T_STRING,
+    'title' => 'New token name',
+  ];
+
+  $params['value'] = [
+    'name' => 'value',
+    'api.required' => 1,
+    'type' => CRM_Utils_Type::T_STRING,
+    'title' => 'New token value',
+  ];
+}

--- a/sqltasks.php
+++ b/sqltasks.php
@@ -150,7 +150,7 @@ function sqltasks_civicrm_navigationMenu(&$menu) {
     'url'        => 'civicrm/a/#/sqltasks/manage',
     'permission' => 'administer CiviCRM',
     'operator'   => 'OR',
-    'separator'  =>  0,
+    'separator'  => 0,
   ));
   _sqltasks_civix_insert_navigation_menu($menu, 'Contacts', array(
       'label'      => E::ts('My Tasks'),
@@ -158,16 +158,16 @@ function sqltasks_civicrm_navigationMenu(&$menu) {
       'url'        => 'civicrm/sqltasks/mytasks',
       'permission' => 'access CiviCRM',
       'operator'   => 'OR',
-      'separator'  =>  0,
+      'separator'  => 0,
   ));
 
-  _sqltasks_civix_insert_navigation_menu($menu, 'Administer/System Settings', array(
+  _sqltasks_civix_insert_navigation_menu($menu, 'Administer/System Settings/sqltasks_manage', array(
     'label'      => E::ts('Global Token Manager'),
     'name'       => 'global_token_manager',
     'url'        => 'civicrm/sqltasks/global-token-manager',
     'permission' => 'administer CiviCRM',
     'operator'   => 'OR',
-    'separator'  =>  0,
+    'separator'  => 0,
   ));
 
   _sqltasks_civix_navigationMenu($menu);

--- a/sqltasks.php
+++ b/sqltasks.php
@@ -150,7 +150,7 @@ function sqltasks_civicrm_navigationMenu(&$menu) {
     'url'        => 'civicrm/a/#/sqltasks/manage',
     'permission' => 'administer CiviCRM',
     'operator'   => 'OR',
-    'separator'  => 0,
+    'separator'  =>  0,
   ));
   _sqltasks_civix_insert_navigation_menu($menu, 'Contacts', array(
       'label'      => E::ts('My Tasks'),
@@ -158,8 +158,18 @@ function sqltasks_civicrm_navigationMenu(&$menu) {
       'url'        => 'civicrm/sqltasks/mytasks',
       'permission' => 'access CiviCRM',
       'operator'   => 'OR',
-      'separator'  => 0,
+      'separator'  =>  0,
   ));
+
+  _sqltasks_civix_insert_navigation_menu($menu, 'Administer/System Settings', array(
+    'label'      => E::ts('Global Token Manager'),
+    'name'       => 'global_token_manager',
+    'url'        => 'civicrm/sqltasks/global-token-manager',
+    'permission' => 'administer CiviCRM',
+    'operator'   => 'OR',
+    'separator'  =>  0,
+  ));
+
   _sqltasks_civix_navigationMenu($menu);
 }
 

--- a/templates/CRM/Sqltasks/Page/GlobalTokenManager.tpl
+++ b/templates/CRM/Sqltasks/Page/GlobalTokenManager.tpl
@@ -26,11 +26,11 @@
           </thead>
           <tr class="global-token__add-new-token-row">
             <td>
-              <input class="global-token__create-token-name-input" type="text" maxlength="{$maxLengthOfTokenName}">
+              <input class="global-token__create-token-name-input crm-form-text" type="text" maxlength="{$maxLengthOfTokenName}">
               <div class="global-token__create-token-error-message-wrap"></div>
             </td>
             <td>
-              <input class="global-token__create-token-value-input" type="text">
+              <input class="global-token__create-token-value-input crm-form-text" type="text">
             </td>
             <td>
               <div>
@@ -51,7 +51,7 @@
     <tr class="global-token__row-template">
       <td>
         <div class="global-token__edit-mode">
-          <input class="global-token__edit-token-name-input" maxlength="{$maxLengthOfTokenName}" type="text">
+          <input class="global-token__edit-token-name-input crm-form-text" maxlength="{$maxLengthOfTokenName}" type="text">
           <div class="global-token__edit-token-error-message-wrap"></div>
         </div>
         <div class="global-token__view-mode">
@@ -60,7 +60,7 @@
       </td>
       <td>
         <div class="global-token__edit-mode">
-          <input class="global-token__edit-token-value-input" type="text">
+          <input class="global-token__edit-token-value-input crm-form-text" type="text">
         </div>
         <div class="global-token__view-mode">
           <div class="global-token__token-value">
@@ -269,12 +269,15 @@
     max-width: 500px;
   }
 
-  .global-token__add-new-token-row .global-token__create-token-value-input,
-  .global-token__add-new-token-row .global-token__create-token-name-input {
+  .global-token__page .global-token__add-new-token-row .global-token__create-token-value-input,
+  .global-token__page .global-token__add-new-token-row .global-token__create-token-name-input ,
+  .global-token__page .global-token__row .global-token__edit-token-name-input ,
+  .global-token__page .global-token__row .global-token__edit-token-value-input {
     width: 100%;
     max-width: 100%;
     display: block;
     box-sizing: border-box;
+    height: 30px;
   }
 </style>
 {/literal}

--- a/templates/CRM/Sqltasks/Page/GlobalTokenManager.tpl
+++ b/templates/CRM/Sqltasks/Page/GlobalTokenManager.tpl
@@ -3,10 +3,9 @@
     <div class="crm-content-block crm-block">
 
       <div class="help">
-        <p>{ts}This is list of tokens. These tokens can be used in sqltasks.{/ts}</p>
-        <p>{ts}Example of usage:{/ts}</p>
-        <p>&lt;config&gt;{ts}[your token name]{/ts}&lt;/config&gt;</p>
-        <p>{ts}You can create new one.{/ts}</p>
+        <p>{ts}You can manage global tokens below. Global tokens can be used to store values that are used in multiple SQL Tasks, allowing for the value to be changed everywhere by just editing the token. This can be useful for things like credentials.{/ts}</p>
+        <p>{ts}To use a global token, use this syntax in any task field:{/ts}</p>
+        <p><code>{ts}{literal}{config.name_of_token}{/literal}{/ts}</code></p>
       </div>
 
       <div class="global-token__table-wrap">
@@ -174,10 +173,10 @@
                 var tokenName = tokenRow.data('token-name');
                 CRM.api3('SqltaskGlobalToken', 'delete_token', {"name": tokenName}).done(function(result) {
                     if (result.is_error === 0) {
-                        CRM.alert(ts('Task global token successfully deleted!'), ts("Deliting global token"), "success");
+                        CRM.alert(ts('Global token successfully deleted!'), ts("Deleting global token"), "success");
                         tokenRow.remove();
                     } else {
-                        CRM.alert(result.error_message, ts("Deliting global token error"), "error");
+                        CRM.alert(result.error_message, ts("Error deleting global token"), "error");
                     }
                 });
             });

--- a/templates/CRM/Sqltasks/Page/GlobalTokenManager.tpl
+++ b/templates/CRM/Sqltasks/Page/GlobalTokenManager.tpl
@@ -1,0 +1,280 @@
+<div class="global-token__page">
+  <div class="crm-block crm-form-block page-civicrm-admin">
+    <div class="crm-content-block crm-block">
+
+      <div class="help">
+        <p>{ts}This is list of tokens. These tokens can be used in sqltasks.{/ts}</p>
+        <p>{ts}Example of usage:{/ts}</p>
+        <p>&lt;config&gt;{ts}[your token name]{/ts}&lt;/config&gt;</p>
+        <p>{ts}You can create new one.{/ts}</p>
+      </div>
+
+      <div class="global-token__table-wrap">
+        <table class="global-token__table form-layout">
+          <thead>
+            <tr>
+              <th class="global-token__large-column">
+                  {ts}Name{/ts}
+              </th>
+              <th class="global-token__large-column">
+                  {ts}Value{/ts}
+              </th>
+              <th>
+                  {ts}Actions{/ts}
+              </th>
+            </tr>
+          </thead>
+          <tr class="global-token__add-new-token-row">
+            <td>
+              <input class="global-token__create-token-name-input" type="text" maxlength="{$maxLengthOfTokenName}">
+              <div class="global-token__create-token-error-message-wrap"></div>
+            </td>
+            <td>
+              <input class="global-token__create-token-value-input" type="text">
+            </td>
+            <td>
+              <div>
+                <a class="button global-token__button" id="globalTokenCreateButton" href="javascript:;">
+                  <span><i class="crm-i fa-plus-circle"></i><span>{ts}Create new global token{/ts}</span></span>
+                </a>
+              </div>
+            </td>
+          </tr>
+        </table>
+      </div>
+
+    </div>
+  </div>
+
+  {*this table is hidden and the row will be used like a template*}
+  <table class="global-token__table-template">
+    <tr class="global-token__row-template">
+      <td>
+        <div class="global-token__edit-mode">
+          <input class="global-token__edit-token-name-input" maxlength="{$maxLengthOfTokenName}" type="text">
+          <div class="global-token__edit-token-error-message-wrap"></div>
+        </div>
+        <div class="global-token__view-mode">
+          <div class="global-token__token-name"></div>
+        </div>
+      </td>
+      <td>
+        <div class="global-token__edit-mode">
+          <input class="global-token__edit-token-value-input" type="text">
+        </div>
+        <div class="global-token__view-mode">
+          <div class="global-token__token-value">
+          </div>
+        </div>
+      </td>
+      <td>
+        <div class="global-token__edit-mode">
+          <a class="button global-token__button global-token__update-token-data-button" href="javascript:;">
+            <span><i class="crm-i fa-check"></i><span>{ts}Update{/ts}</span></span>
+          </a>
+          <a class="button global-token__button global-token__cancel-editing-token-data-button" href="javascript:;">
+            <span><i class="crm-i fa-close"></i><span>{ts}Cancel{/ts}</span></span>
+          </a>
+        </div>
+        <div class="global-token__view-mode">
+          <a class="button global-token__button global-token__edit-token-data-button" href="javascript:;">
+            <span><i class="crm-i fa-pencil"></i><span>{ts}Edit{/ts}</span></span>
+          </a>
+          <a class="button global-token__button global-token__delete-token-button" href="javascript:;">
+            <span><i class="crm-i fa-trash"></i><span>{ts}Delete{/ts}</span></span>
+          </a>
+        </div>
+      </td>
+    </tr>
+  </table>
+
+</div>
+
+{literal}
+<script>
+    CRM.$(function ($) {
+        var tokens = {/literal}{$tokens}{literal};
+        var templateColumns = $('.global-token__table-template .global-token__row-template').html();
+        var table =  $('.global-token__table');
+        var createTokenErrorMessageElement =  $('.global-token__create-token-error-message-wrap');
+
+        addTokensToTable();
+        initCreatingNewToken();
+
+        function addTokensToTable() {
+            for (var i = 0; i < tokens.length; i++) {
+                addTokenToTable(tokens[i]);
+            }
+        }
+
+        function addTokenToTable(token) {
+            table.find('.global-token__add-new-token-row').before('<tr class="global-token__row" data-token-name="' + token.name + '"></td>');
+            var tokenRow = $("tr.global-token__row[data-token-name='" + token.name + "']");
+            tokenRow.append(templateColumns);
+
+            tokenRow.find('.global-token__token-name').text(token.name);
+            tokenRow.find('.global-token__token-value').text(token.value);
+
+            tokenRow.find('.global-token__edit-token-data-button').click(function () {
+                tokenRow.addClass('edit-mode');
+                tokenRow.find('.global-token__edit-token-name-input').val(tokenRow.find('.global-token__token-name').text());
+                tokenRow.find('.global-token__edit-token-value-input').val(tokenRow.find('.global-token__token-value').text());
+            });
+
+            tokenRow.find('.global-token__delete-token-button').click(function () {
+                showDeleteTokenWindow(tokenRow);
+            });
+
+            tokenRow.find('.global-token__update-token-data-button').click(function () {
+                updateTokenData(tokenRow);
+            });
+
+            tokenRow.find('.global-token__cancel-editing-token-data-button').click(function () {
+                tokenRow.removeClass('edit-mode');
+            });
+
+            return tokenRow;
+        }
+
+        function updateTokenData(tokenRow) {
+            var newName = tokenRow.find('.global-token__edit-token-name-input').val();
+            var value = tokenRow.find('.global-token__edit-token-value-input').val();
+            var name = tokenRow.data('token-name');
+            var errorMessageElement = tokenRow.find('.global-token__edit-token-error-message-wrap');
+            errorMessageElement.empty();
+
+            if (newName.length < 1) {
+                errorMessageElement.append(getErrorMessageHtml(ts("Name cannot be empty.")));
+                return;
+            }
+
+            CRM.api3('SqltaskGlobalToken', 'update_token', {
+                "new_name": newName,
+                "value": value,
+                "name": name
+            }).done(function(result) {
+                if (result.is_error === 0) {
+                    tokenRow.removeClass('edit-mode');
+                    tokenRow.find('.global-token__token-name').text(newName);
+                    tokenRow.find('.global-token__token-value').text(value);
+                    tokenRow.data('token-name', newName);
+                    tokenRow.effect('highlight', {}, 1500);
+                    CRM.alert(ts('Global token successfully updated!'), ts("Updating global token"), "success");
+                } else {
+                    errorMessageElement.append(getErrorMessageHtml(result.error_message));
+                }
+            });
+        }
+
+        function showDeleteTokenWindow(tokenRow) {
+            CRM.confirm({
+                title: ts('Remove global token'),
+                message: ts('Are you sure?'),
+            }).on('crmConfirm:yes', function() {
+                var tokenName = tokenRow.data('token-name');
+                CRM.api3('SqltaskGlobalToken', 'delete_token', {"name": tokenName}).done(function(result) {
+                    if (result.is_error === 0) {
+                        CRM.alert(ts('Task global token successfully deleted!'), ts("Deliting global token"), "success");
+                        tokenRow.remove();
+                    } else {
+                        CRM.alert(result.error_message, ts("Deliting global token error"), "error");
+                    }
+                });
+            });
+        }
+
+        function initCreatingNewToken() {
+            $('#globalTokenCreateButton').click(function () {
+                var row = $(this).closest('.global-token__add-new-token-row');
+                var nameElement = row.find('.global-token__create-token-name-input');
+                var valueElement = row.find('.global-token__create-token-value-input');
+                var name = nameElement.val();
+                var value = valueElement.val();
+                createTokenErrorMessageElement.empty();
+
+                if (name.length < 1) {
+                    createTokenErrorMessageElement.append(getErrorMessageHtml(ts("Name cannot be empty.")));
+                    return;
+                }
+
+                CRM.api3('SqltaskGlobalToken', 'create', {
+                    "name": name,
+                    "value": value
+                }).done(function(result) {
+                    if (result.is_error === 0) {
+                        var tokenRow = addTokenToTable({'name' : name, 'value' : value});
+                        tokenRow.effect('highlight', {}, 1500);
+                        valueElement.val('');
+                        nameElement.val('');
+                        CRM.alert(ts('Global token successfully created!'), ts("Creating global token"), "success");
+                    } else {
+                        createTokenErrorMessageElement.append(getErrorMessageHtml(result.error_message));
+                    }
+                });
+            });
+        }
+
+        function getErrorMessageHtml(message) {
+            return '<span class="crm-error">' + message + '</span>';
+        }
+
+    });
+</script>
+
+<style>
+  .global-token__edit-mode {
+    display: none;
+  }
+
+  .global-token__row.edit-mode .global-token__edit-mode {
+    display: block;
+  }
+
+  .global-token__row.edit-mode .global-token__view-mode {
+    display: none;
+  }
+
+  .global-token__table-template {
+    display: none !important;
+  }
+
+  .global-token__page .global-token__button span span {
+    display: inline-block;
+    vertical-align: middle;
+  }
+
+  .global-token__page .global-token__button span i {
+    display: inline-block;
+    vertical-align: middle;
+    margin: 0 5px 0 0;
+  }
+
+  .global-token__page a:hover .crm-i.fa-trash {
+    color: inherit;
+  }
+
+  .global-token__button {
+    white-space: nowrap;
+  }
+
+  .global-token__large-column {
+    width: 50%;
+  }
+
+  .global-token__token-value {
+    max-width: 600px;
+  }
+
+  .global-token__token-name {
+    max-width: 500px;
+  }
+
+  .global-token__add-new-token-row .global-token__create-token-value-input,
+  .global-token__add-new-token-row .global-token__create-token-name-input {
+    width: 100%;
+    max-width: 100%;
+    display: block;
+    box-sizing: border-box;
+  }
+</style>
+{/literal}

--- a/tests/phpunit/CRM/Sqltasks/TaskTest.php
+++ b/tests/phpunit/CRM/Sqltasks/TaskTest.php
@@ -192,7 +192,7 @@ class CRM_Sqltasks_TaskTest extends CRM_Sqltasks_AbstractTaskTest {
   public function testGlobalTokens() {
     $tmp = tempnam(sys_get_temp_dir(), 'csv');
     // add a global token setting that will be available via {config.*}
-    Civi::settings()->set('sqltasks_global_tokens', ['test' => 'expected_config_value']);
+    (CRM_Sqltasks_GlobalToken::singleton())->setValue('test', 'expected_config_value');
     // add context and setting token to file
     $tmp .= '_{context.input_val}_{setting.lcMessages}.csv';
     $data = [
@@ -252,7 +252,7 @@ class CRM_Sqltasks_TaskTest extends CRM_Sqltasks_AbstractTaskTest {
     );
     $config = CRM_Core_DAO::singleValueQuery("SELECT config FROM tmp_test_input_value");
     $this->assertEquals(
-      Civi::settings()->get('sqltasks_global_tokens')['test'],
+      (CRM_Sqltasks_GlobalToken::singleton())->getValue('test'),
       $config,
       'Column "config" should match setting in sqltasks_global_tokens'
     );

--- a/xml/Menu/sqltasks.xml
+++ b/xml/Menu/sqltasks.xml
@@ -37,4 +37,10 @@
     <access_arguments>access CiviCRM</access_arguments>
     <access_arguments>administer CiviCRM</access_arguments>
   </item>
+  <item>
+    <path>civicrm/sqltasks/global-token-manager</path>
+    <page_callback>CRM_Sqltasks_Page_GlobalTokenManager</page_callback>
+    <title>Global Token Manager</title>
+    <access_arguments>administer CiviCRM</access_arguments>
+  </item>
 </menu>


### PR DESCRIPTION
- Added page(`civicrm/sqltasks/global-token-manager`) where you can dynamically view/edit/create/delete global tokens:

![global-token-manager](https://user-images.githubusercontent.com/36959503/84270520-7900d180-ab33-11ea-9640-64749bbef70b.png)

- Link to that page added to main menu(Administer->System Settings->Global Token Manager) and to the `SQL Task Manager` page.

- Added adapter class(`CRM_Sqltasks_GlobalToken`) which safely works with sqltasks global tokens.
- Added `SqltaskGlobalToken` APIs. Which is used by JS.