### PR TITLE
GP-11183 Allow multiple instances of task to run

### DIFF
--- a/CRM/Sqltasks/Task.php
+++ b/CRM/Sqltasks/Task.php
@@ -321,7 +321,7 @@ class CRM_Sqltasks_Task {
     }
 
     // 0. mark task as started
-    $is_still_running = CRM_Core_DAO::singleValueQuery("SELECT running_since FROM `civicrm_sqltasks` WHERE id = {$this->task_id};");
+    $is_still_running = CRM_Core_DAO::singleValueQuery("SELECT running_since FROM `civicrm_sqltasks` WHERE id = {$this->task_id} AND parallel_exec != 2");
     if ($is_still_running) {
       $this->status = 'error';
       $this->log("Task is still running. Execution skipped.");
@@ -464,7 +464,7 @@ class CRM_Sqltasks_Task {
    * Get a list of tasks ready for execution
    */
   public static function getParallelExecutionTaskList() {
-    return self::getTasks('SELECT * FROM civicrm_sqltasks WHERE enabled=1 AND parallel_exec = 1 ORDER BY weight ASC, id ASC');
+    return self::getTasks('SELECT * FROM civicrm_sqltasks WHERE enabled=1 AND parallel_exec IN (1, 2) ORDER BY weight ASC, id ASC');
   }
 
   /**

--- a/ang/sqlTaskConfigurator.js
+++ b/ang/sqlTaskConfigurator.js
@@ -283,7 +283,7 @@
         if (defaultOption === "always" && !Number(taskId)) {
           $scope.taskOptions.scheduled = defaultOption;
           $scope.taskOptions.enabled = 0;
-          $scope.taskOptions.parallel_exec = 0;
+          $scope.taskOptions.parallel_exec = '0';
           $scope.taskOptions.input_required = 0;
           $scope.config = Object.assign($scope.config, {
             scheduled_month: 1,

--- a/ang/sqlTaskConfigurator/sqlTaskConfigurator.html
+++ b/ang/sqlTaskConfigurator/sqlTaskConfigurator.html
@@ -294,8 +294,11 @@
                                 href="javascript:;" title="{{ts('Help')}}" class="helpicon">&nbsp;</a>
                         </div>
                         <div class="content">
-                            <input ng-true-value="'1'" ng-false-value="'0'" ng-model="taskOptions.parallel_exec"
-                                   id="parallel_exec" name="parallel_exec" type="checkbox" class="crm-form-checkbox">
+                            <select ng-model="taskOptions.parallel_exec" name="parallel_exec" id="parallel_exec" class="crm-form-select">
+                                <option value="0" selected="selected">no</option>
+                                <option value="1">With other running tasks</option>
+                                <option value="2">Always (multiple instances)</option>
+                            </select>
                         </div>
                         <div class="clear"></div>
                     </div>

--- a/ang/sqlTaskManager/sqlTaskManager.html
+++ b/ang/sqlTaskManager/sqlTaskManager.html
@@ -145,7 +145,7 @@
               <td>{{getNumberFromString(task.enabled) ? 'Yes' : 'No'}}</td>
               <td>
                   <span>{{task.schedule_label}}</span>
-                  <span ng-if="getBooleanFromNumber(task.parallel_exec)"><strong>{{ts('(parallel)')}}</strong></span>
+                  <span ng-if="task.parallel_exec != 0"><strong>{{ts('(parallel)')}}</strong></span>
               </td>
               <td>
                   <div class="sql-task-table-column-last-executed">

--- a/api/v3/Sqltask/Create.php
+++ b/api/v3/Sqltask/Create.php
@@ -14,7 +14,7 @@ function civicrm_api3_sqltask_create($params) {
     'input_required','enabled', 'weight', 'run_permissions'
   ];
 
-  $booleanParams = ['parallel_exec', 'input_required', 'enabled'];
+  $booleanParams = ['input_required', 'enabled'];
   foreach ($booleanParams as $booleanParam) {
     if (array_key_exists($booleanParam, $params) && !($params[$booleanParam] == '1' || $params[$booleanParam] == '0')) {
       return civicrm_api3_create_error('Field \'' . $booleanParam . '\' must be \'0\' or \'1\'.');
@@ -149,7 +149,7 @@ function _civicrm_api3_sqltask_create_spec(&$params) {
   $params['parallel_exec'] = [
     'name'         => 'parallel_exec',
     'api.required' => 0,
-    'type'         => CRM_Utils_Type::T_BOOLEAN,
+    'type'         => CRM_Utils_Type::T_INT,
     'title'        => 'Allow parallel execution?',
     'description'  => 'Whether to allow multiple instances of this task to run at the same time',
   ];

--- a/templates/CRM/Sqltasks/Form/Configure.hlp
+++ b/templates/CRM/Sqltasks/Form/Configure.hlp
@@ -22,8 +22,17 @@
 {/htxt}
 
 {htxt id='id-configure-parallel'}
-  <p>{ts domain="de.systopia.sqltasks"}If you enable this flag, this task will be executed even if other tasks are still running.{/ts}</p>
-  <p>{ts domain="de.systopia.sqltasks"}It does <i>not</i> mean, that this task itself will be executed in multiple instances at the same time.{/ts}</p>
+  <p>{ts domain="de.systopia.sqltasks"}This option lets you decide whether a task should run in parallel. The following options are available:{/ts}</p>
+
+  <dl>
+    <dt>{ts domain="de.systopia.sqltasks"}No{/ts}</dt>
+    <dd>{ts domain="de.systopia.sqltasks"}The task will not run if any other tasks are already running.{/ts}</dd>
+    <dt>{ts domain="de.systopia.sqltasks"}With other running tasks{/ts}</dt>
+    <dd>{ts domain="de.systopia.sqltasks"}The task will be executed even if other tasks are still running, but not if the task itself is already running.{/ts}</dd>
+    <dt>{ts domain="de.systopia.sqltasks"}Always (multiple instances){/ts}</dt>
+    <dd>{ts domain="de.systopia.sqltasks"}The task will always be executed, potentially causing multiple instances of the task to run in parallel.{/ts}</dd>
+  </dl>
+  <p><strong>{ts domain="de.systopia.sqltasks"}Important: With the last option, you are responsible for ensuring multiple instances of the task can run in parallel. That means keeping all identifiers (like table names) unique and ensuring no deadlocks occur.{/ts}</strong></p>
 {/htxt}
 
 {htxt id='id-configure-main'}


### PR DESCRIPTION
This changes the `parallel_exec` task option to allow a third option called "Always (multiple instances)". When this option is selected, multiple instances of the same task can run in parallel. This is particularly useful for tasks triggered by CiviRules, where rules can potentially be triggered in parallel.