### PR TITLE
Gp 14049: Add options to handle API errors.

### DIFF
--- a/CRM/Sqltasks/Action/APICall.php
+++ b/CRM/Sqltasks/Action/APICall.php
@@ -25,6 +25,25 @@ use CRM_Sqltasks_ExtensionUtil as E;
 class CRM_Sqltasks_Action_APICall extends CRM_Sqltasks_Action {
 
   /**
+   * Log only
+   * Is default
+   * (this is setting option which set how to handle API errors)
+   */
+  const LOG_ONLY = 'log_only';
+
+  /**
+   * Report task error and continue API calls
+   * (this is setting option which set how to handle API errors)
+   */
+  const REPORT_ERROR_AND_CONTINUE = 'report_error_and_continue';
+
+  /**
+   * Report task error and abort API calls
+   * (this is setting option which set how to handle API errors)
+   */
+  const REPORT_ERROR_AND_ABORT = 'report_error_and_abort';
+
+  /**
    * Get identifier string
    */
   public function getID() {
@@ -48,7 +67,7 @@ class CRM_Sqltasks_Action_APICall extends CRM_Sqltasks_Action {
   }
 
   /**
-   * get the table with the contact_id column
+   * Get the table with the contact_id column
    */
   protected function getDataTable() {
     $table_name = $this->getConfigValue('table');
@@ -84,12 +103,12 @@ class CRM_Sqltasks_Action_APICall extends CRM_Sqltasks_Action {
   }
 
   /**
-   * get a list of (param, value) definitions
+   * Get a list of (param, value) definitions
    */
   protected function getParameters() {
     $parameters = array();
-    $paremeters_spec = trim($this->getConfigValue('parameters'));
-    $spec_lines = explode(PHP_EOL, $paremeters_spec);
+    $parameters_spec = trim($this->getConfigValue('parameters'));
+    $spec_lines = explode(PHP_EOL, $parameters_spec);
     foreach ($spec_lines as $spec_line) {
       $separator_index = strpos($spec_line, '=');
       if ($separator_index > 0) {
@@ -107,7 +126,7 @@ class CRM_Sqltasks_Action_APICall extends CRM_Sqltasks_Action {
   }
 
   /**
-   * generate a parameter set for the given data row
+   * Generate a parameter set for the given data row
    */
   protected function fillParameters($specs, $data_row) {
     $parameters = array();
@@ -135,6 +154,12 @@ class CRM_Sqltasks_Action_APICall extends CRM_Sqltasks_Action {
    * RUN this action
    */
   public function execute() {
+    $handle_api_errors = $this->getHandleApiErrors();
+    $this->log('Start API call(s) action ...');
+    if ($handle_api_errors !== self::LOG_ONLY) {
+      $this->log("API call error handling mode is: " . self::getHandleApiErrorsOptions()[$handle_api_errors]);
+    }
+
     // API Call specs
     $this->resetHasExecuted();
     $entity = $this->getConfigValue('entity');
@@ -143,25 +168,43 @@ class CRM_Sqltasks_Action_APICall extends CRM_Sqltasks_Action {
 
     // statistics
     $success_counter = 0;
-    $fails = array();
+    $fails = [];
     $more_fails_counter = 0;
+    $skip_counter = 0;
 
     $data_table = $this->getDataTable();
     $excludeSql = '';
+    $is_need_to_skip = false;
     if ($this->_columnExists($data_table, 'exclude')) {
       $excludeSql = 'WHERE (exclude IS NULL OR exclude != 1)';
       $this->log('Column "exclude" exists, might skip some rows');
     }
     $query = CRM_Core_DAO::executeQuery("SELECT * FROM {$data_table} {$excludeSql}");
     while ($query->fetch()) {
+      if ($is_need_to_skip) {
+        $skip_counter += 1;
+        continue;
+      }
+
       $this->setHasExecuted();
       $parameters = $this->fillParameters($parameter_specs, $query);
       try {
         // error_log("Calling {$entity}.{$action}: " . json_encode($parameters));
         $result = civicrm_api3($entity, $action, $parameters);
       } catch (Exception $e) {
-        $result = array('is_error'  => 1,
-                        'error_msg' => $e->getMessage());
+        $result = [
+          'is_error'  => 1,
+          'error_msg' => $e->getMessage()
+        ];
+
+        if (in_array($handle_api_errors, [self::REPORT_ERROR_AND_CONTINUE, self::REPORT_ERROR_AND_ABORT])) {
+            $this->reportError($e->getMessage(), $entity, $action, $parameters);
+        }
+
+        if ($handle_api_errors === self::REPORT_ERROR_AND_ABORT) {
+          $this->log("API call returns error. Next API call(s) will be skipped.");
+          $is_need_to_skip = true;
+        }
       }
 
       // process result
@@ -193,5 +236,49 @@ class CRM_Sqltasks_Action_APICall extends CRM_Sqltasks_Action {
     if ($more_fails_counter) {
       $this->log("{$more_fails_counter} API call(s) FAILED with other messages.");
     }
+    if ($skip_counter) {
+      $this->log("{$skip_counter} API call(s) SKIPPED.");
+    }
   }
+
+  /**
+   * Get all possible options of handling API errors
+   *
+   * @return array
+   */
+  public static function getHandleApiErrorsOptions() {
+    return [
+      self::LOG_ONLY => E::ts('Log only'),
+      self::REPORT_ERROR_AND_CONTINUE => E::ts('Report task error and continue API calls'),
+      self::REPORT_ERROR_AND_ABORT => E::ts('Report task error and abort API calls'),
+    ];
+  }
+
+  /**
+   * Gets handle Api errors value
+   * If the value is empty or not valid it returns default value
+   *
+   * @return string
+   */
+  private function getHandleApiErrors() {
+    $handle_api_errors = $this->getConfigValue('handle_api_errors');
+    if (key_exists($handle_api_errors, self::getHandleApiErrorsOptions())) {
+      return $handle_api_errors;
+    }
+
+    return self::LOG_ONLY;
+  }
+
+  /**
+   * Report API call error
+   *
+   * @param $errorMessage
+   * @param $entity
+   * @param $action
+   * @param $parameters
+   */
+  protected function reportError($errorMessage, $entity, $action, $parameters) {
+    //TODO: make report
+  }
+
 }

--- a/CRM/Sqltasks/Action/APICall.php
+++ b/CRM/Sqltasks/Action/APICall.php
@@ -278,7 +278,11 @@ class CRM_Sqltasks_Action_APICall extends CRM_Sqltasks_Action {
    * @param $parameters
    */
   protected function reportError($errorMessage, $entity, $action, $parameters) {
-    //TODO: make report
+    $this->task->log('Report API call(' .  $entity . '->' . $action . ')');
+    $this->task->log('Params:' . json_encode($parameters));
+    $this->task->log('Error message:' . $errorMessage);
+    $this->task->incrementErrorCounter();
+    $this->task->setErrorStatus();
   }
 
 }

--- a/CRM/Sqltasks/Task.php
+++ b/CRM/Sqltasks/Task.php
@@ -135,6 +135,20 @@ class CRM_Sqltasks_Task {
   }
 
   /**
+   * Add +1 to error counter
+   */
+  public function incrementErrorCounter() {
+    $this->error_count += 1;
+  }
+
+  /**
+   * Sets error status
+   */
+  public function setErrorStatus() {
+    $this->status = 'error';
+  }
+
+  /**
    * Get configuration
    */
   public function getConfiguration() {

--- a/ang/actions/APICall.html
+++ b/ang/actions/APICall.html
@@ -34,6 +34,14 @@
                     helpaction='onInfoPress("Action", "id-api-action", "CRM\/Sqltasks\/Action\/APICall")'>
             </text-input>
 
+			<ordinary-select2 isrequired="getBooleanFromNumber(ctrl.model['enabled'])"
+							  showHelpIcon=true inputMaxWidth="'300px'"
+							  model="ctrl.model['handle_api_errors']" fieldlabel="ts('Choose Error Handling Type')"
+							  fieldid="'handle_api_errors' + ctrl.index" optionsArray="handleApiErrorsData"
+							  isdataloaded="isDataLoaded('handle_api_errors_index_' + ctrl.index)"
+							  helpaction='onInfoPress("Choose Error Handling Type", "id-handle-api-errors", "CRM\/Sqltasks\/Action\/APICall")'>
+			</ordinary-select2>
+
             <text-area isrequired="getBooleanFromNumber(ctrl.model['parameters'])" model="ctrl.model['parameters']"
                        fieldlabel="ts('Parameters')" fieldid="'api_call_parameters' + ctrl.index" rowsnumber='8' inputMaxWidth="'500px'"
                        helpaction='onInfoPress("Columns", "id-api-parameters", "CRM\/Sqltasks\/Action\/APICall")'

--- a/ang/actions/APICall.html
+++ b/ang/actions/APICall.html
@@ -36,10 +36,10 @@
 
 			<ordinary-select2 isrequired="getBooleanFromNumber(ctrl.model['enabled'])"
 							  showHelpIcon=true inputMaxWidth="'300px'"
-							  model="ctrl.model['handle_api_errors']" fieldlabel="ts('Choose Error Handling Type')"
+							  model="ctrl.model['handle_api_errors']" fieldlabel="ts('Error Handling')"
 							  fieldid="'handle_api_errors' + ctrl.index" optionsArray="handleApiErrorsData"
 							  isdataloaded="isDataLoaded('handle_api_errors_index_' + ctrl.index)"
-							  helpaction='onInfoPress("Choose Error Handling Type", "id-handle-api-errors", "CRM\/Sqltasks\/Action\/APICall")'>
+							  helpaction='onInfoPress("Error Handling", "id-handle-api-errors", "CRM\/Sqltasks\/Action\/APICall")'>
 			</ordinary-select2>
 
             <text-area isrequired="getBooleanFromNumber(ctrl.model['parameters'])" model="ctrl.model['parameters']"

--- a/ang/sqlTaskConfigurator.js
+++ b/ang/sqlTaskConfigurator.js
@@ -529,7 +529,7 @@
       },
       bindToController: true,
       controllerAs: "ctrl",
-      controller: function($scope, loaderService) {
+      controller: function($scope, loaderService) {;
         $scope.ts = CRM.ts();
         $scope.removeItemFromArray = removeItemFromArray;
         $scope.getBooleanFromNumber = getBooleanFromNumber;
@@ -537,6 +537,11 @@
         $scope.isDataLoaded = function(elementId) {
           return loaderService.isDataLoaded(elementId);
         };
+
+        if ($scope.ctrl.model.handle_api_errors === undefined) {
+          // apply backend default in UI
+          $scope.ctrl.model.handle_api_errors = 'log_only';
+        }
 
         $scope.handleApiErrorsOptions = [];
         CRM.api3("Sqltaskfield", "get_handle_api_errors_options", {

--- a/ang/sqlTaskConfigurator.js
+++ b/ang/sqlTaskConfigurator.js
@@ -529,11 +529,36 @@
       },
       bindToController: true,
       controllerAs: "ctrl",
-      controller: function($scope) {
+      controller: function($scope, loaderService) {
         $scope.ts = CRM.ts();
         $scope.removeItemFromArray = removeItemFromArray;
         $scope.getBooleanFromNumber = getBooleanFromNumber;
         $scope.onInfoPress = onInfoPress;
+        $scope.isDataLoaded = function(elementId) {
+          return loaderService.isDataLoaded(elementId);
+        };
+
+        $scope.handleApiErrorsOptions = [];
+        CRM.api3("Sqltaskfield", "get_handle_api_errors_options", {
+          sequential: 1,
+          options: {limit : 0}
+        }).done(function(result) {
+          if (!result.is_error) {
+            var handleApiErrorsOptions = [];
+            Object.keys(result.values[0]).map(key => {
+              var entity = result.values[0][key];
+              if (key) {
+                handleApiErrorsOptions.push({
+                  value: key,
+                  name: entity
+                });
+              }
+            });
+            $scope.handleApiErrorsData = handleApiErrorsOptions;
+            loaderService.setDataLoaded('handle_api_errors_index_' + $scope.ctrl.index);
+            $scope.$apply();
+          }
+        });
       }
     };
   });

--- a/ang/sqlTaskConfigurator/sqlTaskConfigurator.html
+++ b/ang/sqlTaskConfigurator/sqlTaskConfigurator.html
@@ -295,7 +295,7 @@
                         </div>
                         <div class="content">
                             <select ng-model="taskOptions.parallel_exec" name="parallel_exec" id="parallel_exec" class="crm-form-select">
-                                <option value="0" selected="selected">no</option>
+                                <option value="0" selected="selected">No</option>
                                 <option value="1">With other running tasks</option>
                                 <option value="2">Always (multiple instances)</option>
                             </select>

--- a/api/v3/Sqltaskfield/GetHandleApiErrorsOptions.php
+++ b/api/v3/Sqltaskfield/GetHandleApiErrorsOptions.php
@@ -1,0 +1,10 @@
+<?php
+
+/**
+ * Gets list of 'handle api errors' options
+ *
+ * @return array
+ */
+function civicrm_api3_sqltaskfield_get_handle_api_errors_options() {
+  return civicrm_api3_create_success([CRM_Sqltasks_Action_APICall::getHandleApiErrorsOptions()]);
+}

--- a/templates/CRM/Sqltasks/Action/APICall.hlp
+++ b/templates/CRM/Sqltasks/Action/APICall.hlp
@@ -37,3 +37,24 @@
   <p>{ts domain="de.systopia.sqltasks"}&nbsp;&nbsp;<code>first_name={literal}{contact_first_name}{/literal}</code><br/>&nbsp;&nbsp;<code>contact_type=Individual</code>{/ts}</p>
   <p>{ts domain="de.systopia.sqltasks"}Each line that doesn't follow this format will be ignored.{/ts}</p>
 {/htxt}
+
+{htxt id='id-handle-api-errors'}
+  <p>{ts domain="de.systopia.sqltasks"}This option lets you decide how handle API errors. The following options are available:{/ts}</p>
+
+  <ul>
+     <li>
+         <dt>{ts domain="de.systopia.sqltasks"}Log only(default){/ts}</dt>
+         <dd>{ts domain="de.systopia.sqltasks"}{/ts}</dd>
+     </li>
+
+     <li>
+        <dt>{ts domain="de.systopia.sqltasks"}Report task error and continue API calls{/ts}</dt>
+        <dd>{ts domain="de.systopia.sqltasks"}{/ts}</dd>
+     </li>
+
+     <li>
+        <dt>{ts domain="de.systopia.sqltasks"}Report task error and abort API calls{/ts}</dt>
+        <dd>{ts domain="de.systopia.sqltasks"}{/ts}</dd>
+     </li>
+  </ul>
+{/htxt}

--- a/templates/CRM/Sqltasks/Action/APICall.hlp
+++ b/templates/CRM/Sqltasks/Action/APICall.hlp
@@ -43,18 +43,18 @@
 
   <ul>
      <li>
-         <dt>{ts domain="de.systopia.sqltasks"}Log only(default){/ts}</dt>
-         <dd>{ts domain="de.systopia.sqltasks"}{/ts}</dd>
+         <dt>{ts domain="de.systopia.sqltasks"}Log only (default){/ts}</dt>
+         <dd>{ts domain="de.systopia.sqltasks"}Log API errors and continue. Don't trigger Error Handler action.{/ts}</dd>
      </li>
 
      <li>
         <dt>{ts domain="de.systopia.sqltasks"}Report task error and continue API calls{/ts}</dt>
-        <dd>{ts domain="de.systopia.sqltasks"}{/ts}</dd>
+        <dd>{ts domain="de.systopia.sqltasks"}Continue with remaining API calls and then report task error to Error Handler.{/ts}</dd>
      </li>
 
      <li>
         <dt>{ts domain="de.systopia.sqltasks"}Report task error and abort API calls{/ts}</dt>
-        <dd>{ts domain="de.systopia.sqltasks"}{/ts}</dd>
+        <dd>{ts domain="de.systopia.sqltasks"}Abort remaining API calls and report task error to Error Handler.{/ts}</dd>
      </li>
   </ul>
 {/htxt}


### PR DESCRIPTION
Added new dropdown with 3 options: 
* Log only
* Report task error and continue API calls
* Report task error and abort API calls

The dropdown is located in `API Call` action:
![api-call](https://user-images.githubusercontent.com/36959503/108503633-61cad400-72bd-11eb-96f6-7922665c1b68.png)

**Case 1:**
Handle api errors mode = `Log only`
And called api returns some error.

The log of `Api Call` action will be:
![log_only](https://user-images.githubusercontent.com/36959503/108504419-81aec780-72be-11eb-9fbb-2fe6be3eb863.png)

**Case 2:**
Handle api errors mode = `Report task error and continue API calls`
And called api returns some error.
Action will set task status = `error` and log more detailed.
If `Error Handler` action has checked 'attach log' it can sends logs to email.
Each API error will be reported.

The log of `Api Call` action will be:
![report_error_and_continue](https://user-images.githubusercontent.com/36959503/108504438-87a4a880-72be-11eb-944d-041e8aad392d.png)

**Case 3:**
Handle api errors mode = `Report task error and abort API calls`
And called api returns some error.
Action will set task status = `error` and log more detailed.
If `Error Handler` action has checked 'attach log' it can sends logs to email.
First API error will be reported.
Other API wil be skiped.

The log of `Api Call` action will be:
![report_error_and_abort](https://user-images.githubusercontent.com/36959503/108504444-8d01f300-72be-11eb-9303-f0b56c10dfba.png)

