### PR TITLE
Get entity data by original entity name

### DIFF
--- a/CRM/CivirulesActions/SQLTask.php
+++ b/CRM/CivirulesActions/SQLTask.php
@@ -39,7 +39,7 @@ if (class_exists('CRM_Civirules_Action')) {
         || $triggerData instanceof CRM_Civirules_TriggerData_Cron) {
         $entity = strtolower($triggerData->getEntity());
         $data['entity'] = $entity;
-        $data["{$entity}_data"] = $triggerData->getEntityData($data['entity']);
+        $data["{$entity}_data"] = $triggerData->getEntityData($triggerData->getEntity());
       }
 
       if ($triggerData instanceof CRM_Civirules_TriggerData_Interface_OriginalData) {

--- a/CRM/CivirulesActions/SQLTask.php
+++ b/CRM/CivirulesActions/SQLTask.php
@@ -73,6 +73,17 @@ if (class_exists('CRM_Civirules_Action')) {
 
       return '';
     }
+
+    public static function setCustomFields($event) {
+      $event_data = (array) $event;
+
+      $op = $event_data["action"];
+      $object_name = $event_data["entity"];
+      $object_id = $event_data["id"];
+      $params = $event_data["params"];
+
+      CRM_Civirules_Utils_CustomDataFromPre::pre($op, $object_name, $object_id, $params, null);
+    }
   }
 }
 else {

--- a/sqltasks.php
+++ b/sqltasks.php
@@ -24,6 +24,12 @@ use CRM_Sqltasks_ExtensionUtil as E;
  */
 function sqltasks_civicrm_config(&$config) {
   _sqltasks_civix_civicrm_config($config);
+
+  Civi::dispatcher()->addListener(
+    'hook_civicrm_pre',
+    'CRM_CivirulesActions_SQLTask::setCustomFields',
+    1
+  );
 }
 
 /**

--- a/sqltasks.php
+++ b/sqltasks.php
@@ -25,11 +25,13 @@ use CRM_Sqltasks_ExtensionUtil as E;
 function sqltasks_civicrm_config(&$config) {
   _sqltasks_civix_civicrm_config($config);
 
-  Civi::dispatcher()->addListener(
-    'hook_civicrm_pre',
-    'CRM_CivirulesActions_SQLTask::setCustomFields',
-    1
-  );
+  if (class_exists('CRM_Civirules_Utils_CustomDataFromPre')) {
+    Civi::dispatcher()->addListener(
+      'hook_civicrm_pre',
+      'CRM_CivirulesActions_SQLTask::setCustomFields',
+      1
+    );
+  }
 }
 
 /**


### PR DESCRIPTION
Since https://lab.civicrm.org/extensions/civirules/-/commit/781968761f17da2258dcfd42b07e7b094855bd78 the class `CRM_Civirules_TriggerData_TriggerData` uses the original (capitalized) entity names internally to store entity data.