### PR TITLE
GP-24803 Optimize tag sync queries

### DIFF
--- a/CRM/CivirulesActions/SQLTask.php
+++ b/CRM/CivirulesActions/SQLTask.php
@@ -74,18 +74,6 @@ if (class_exists('CRM_Civirules_Action')) {
       return '';
     }
 
-    public static function setCustomFields($event) {
-      if (!class_exists('CRM_Civirules_Utils_CustomDataFromPre')) return;
-
-      $event_data = (array) $event;
-
-      $op = $event_data["action"];
-      $object_name = $event_data["entity"];
-      $object_id = $event_data["id"];
-      $params = $event_data["params"];
-
-      CRM_Civirules_Utils_CustomDataFromPre::pre($op, $object_name, $object_id, $params, null);
-    }
   }
 }
 else {

--- a/CRM/Sqltasks/Utils.php
+++ b/CRM/Sqltasks/Utils.php
@@ -56,4 +56,17 @@ class CRM_Sqltasks_Utils {
     }
   }
 
+  public static function setCivirulesCustomFields($event) {
+    if (!class_exists('CRM_Civirules_Utils_CustomDataFromPre')) return;
+
+    $event_data = (array) $event;
+
+    $op = $event_data["action"];
+    $object_name = $event_data["entity"];
+    $object_id = $event_data["id"];
+    $params = $event_data["params"];
+
+    CRM_Civirules_Utils_CustomDataFromPre::pre($op, $object_name, $object_id, $params, null);
+  }
+
 }

--- a/sqltasks.php
+++ b/sqltasks.php
@@ -27,7 +27,7 @@ function sqltasks_civicrm_config(&$config) {
 
   Civi::dispatcher()->addListener(
     'hook_civicrm_pre',
-    'CRM_CivirulesActions_SQLTask::setCustomFields',
+    'CRM_Sqltasks_Utils::setCivirulesCustomFields',
     1
   );
 }

--- a/tests/phpunit/CRM/Sqltasks/Action/SyncTagTest.php
+++ b/tests/phpunit/CRM/Sqltasks/Action/SyncTagTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Civi\Api4\EntityTag;
+
 /**
  * Test SyncTag Action
  *
@@ -49,6 +51,36 @@ class CRM_Sqltasks_Action_SyncTagTest extends CRM_Sqltasks_Action_AbstractAction
       'tag_id'       => $tagId,
     ]);
     $this->assertEquals(1, $totalEntityTagCount, 'Should have tagged one contact');
+
+    // create another contact and assign it to the tag
+    $secondContactId = $this->callApiSuccess('Contact', 'create', [
+      'first_name'   => 'Jane',
+      'last_name'    => 'Doe',
+      'contact_type' => 'Individual',
+      'email'        => 'jane.doe@example.com',
+    ])['id'];
+    EntityTag::create(FALSE)
+      ->addValue('entity_table', 'civicrm_contact')
+      ->addValue('entity_id', $secondContactId)
+      ->addValue('tag_id', $tagId)
+      ->execute();
+    $entityTagCount = $this->callApiSuccess('EntityTag', 'getcount', [
+      'entity_table' => 'civicrm_contact',
+      'entity_id'    => $secondContactId,
+      'tag_id'       => $tagId,
+    ]);
+    $this->assertEquals(1, $entityTagCount, 'Second contact should have been tagged');
+
+    // re-run the task and ensure the manually-added contact was removed
+    $this->createAndExecuteTask($data);
+    $this->assertLogContains("Action 'Synchronise Tag' executed in", 'Synchronize Tag action should have succeeded');
+
+    $entityTagCount = $this->callApiSuccess('EntityTag', 'getcount', [
+      'entity_table' => 'civicrm_contact',
+      'entity_id'    => $secondContactId,
+      'tag_id'       => $tagId,
+    ]);
+    $this->assertEquals(0, $entityTagCount, 'Second contact should no longer be tagged');
   }
 
 }


### PR DESCRIPTION
This optimizes tag sync queries by using JOINs instead of IN/NOT IN, which tends to perform worse on MySQL.

This also removes a hard dependency on CiviRules that was accidentally introduced in 65f787243b7269e7aaf22b8e83093dfd328491a9.