### PR TITLE
GP-25284 Fix invalid reply-to header when default inbox missing

### DIFF
--- a/CRM/Sqltasks/Action/CSVExport.php
+++ b/CRM/Sqltasks/Action/CSVExport.php
@@ -350,16 +350,18 @@ class CRM_Sqltasks_Action_CSVExport extends CRM_Sqltasks_Action {
       // add all the variables
       $email_list = $this->getConfigValue('email');
       list($domainEmailName, $domainEmailAddress) = CRM_Core_BAO_Domain::getNameAndEmail();
-      $emailDomain = CRM_Core_BAO_MailSettings::defaultDomain();
 
       // and send the template via email
       $email = array(
           'id'        => $this->getConfigValue('email_template'),
           'to_email'  => $this->getConfigValue('email'),
           'from'      => "SQL Tasks <{$domainEmailAddress}>",
-          'reply_to'  => "do-not-reply@{$emailDomain}",
           'contactId' => CRM_Core_Session::getLoggedInContactID() // sluc: if contactId param is empty, it won't get into hook_civicrm_tokenValues()
         );
+      $emailDomain = CRM_Core_BAO_MailSettings::defaultDomain();
+      if (!empty($emailDomain)) {
+        $email['reply_to'] = "do-not-reply@{$emailDomain}";
+      }
 
       // add file as attachment or setup URL token
       if(!$config_offer_link){

--- a/CRM/Sqltasks/Action/ResultHandler.php
+++ b/CRM/Sqltasks/Action/ResultHandler.php
@@ -158,14 +158,16 @@ abstract class CRM_Sqltasks_Action_ResultHandler extends CRM_Sqltasks_Action {
       // compile email
       $email_list = $this->getConfigValue('email');
       list($domainEmailName, $domainEmailAddress) = CRM_Core_BAO_Domain::getNameAndEmail();
-      $emailDomain = CRM_Core_BAO_MailSettings::defaultDomain();
       $email = array(
         'id'              => $this->getConfigValue('email_template'),
         // 'to_name'         => $this->getConfigValue('email'),
         'to_email'        => $this->getConfigValue('email'),
         'from'            => "SQL Tasks <{$domainEmailAddress}>",
-        'reply_to'        => "do-not-reply@{$emailDomain}",
         );
+      $emailDomain = CRM_Core_BAO_MailSettings::defaultDomain();
+      if (!empty($emailDomain)) {
+        $email['reply_to'] = "do-not-reply@{$emailDomain}";
+      }
 
       // attach the log
       $attach_log = $this->getConfigValue('attach_log');

--- a/CRM/Sqltasks/Action/SegmentationExport.php
+++ b/CRM/Sqltasks/Action/SegmentationExport.php
@@ -300,7 +300,7 @@ class CRM_Sqltasks_Action_SegmentationExport extends CRM_Sqltasks_Action {
       // add all the variables
       $email_list = $this->getConfigValue('email');
       list($domainEmailName, $domainEmailAddress) = CRM_Core_BAO_Domain::getNameAndEmail();
-      $emailDomain = CRM_Core_BAO_MailSettings::defaultDomain();
+
       $attachment  = array('fullPath'  => $filepath,
                            'mime_type' => 'application/zip',
                            'cleanName' => basename($filepath));
@@ -310,9 +310,12 @@ class CRM_Sqltasks_Action_SegmentationExport extends CRM_Sqltasks_Action {
         // 'to_name'         => $this->getConfigValue('email'),
         'to_email'        => $this->getConfigValue('email'),
         'from'            => "SQL Tasks <{$domainEmailAddress}>",
-        'reply_to'        => "do-not-reply@{$emailDomain}",
         'attachments'     => array($attachment),
         );
+      $emailDomain = CRM_Core_BAO_MailSettings::defaultDomain();
+      if (!empty($emailDomain)) {
+        $email['reply_to'] = "do-not-reply@{$emailDomain}";
+      }
       civicrm_api3('MessageTemplate', 'send', $email);
       $this->log("Sent file to '{$email_list}'");
     }


### PR DESCRIPTION
This fixes an issue where an invalid `Reply-To` address is set when there is no default inbox configured on the system. This causes sending errors for at least some SMTP implementations.