### PR TITLE
GP-34970: Change api from 'Segmentation.segmentlist' to 'SegmentationOrder.get_segments'

### DIFF
--- a/ang/sqlTaskConfigurator.js
+++ b/ang/sqlTaskConfigurator.js
@@ -1593,7 +1593,7 @@
         };
 
         if ($scope.model && getBooleanFromNumber($scope.model.campaign_id)) {
-          CRM.api3("Segmentation", "segmentlist", {
+          CRM.api3("SegmentationOrder", "get_segments", {
             campaign_id: $scope.model.campaign_id
           }).done(function(result) {
             var segmentationData = [];
@@ -1644,7 +1644,7 @@
             }, 0);
           });
           if (getBooleanFromNumber(value)) {
-            CRM.api3("Segmentation", "segmentlist", {
+            CRM.api3("SegmentationOrder", "get_segments", {
               campaign_id: value
             }).done(function(result) {
               var segmentationData = [];


### PR DESCRIPTION
Change api from `Segmentation.segmentlist` to `SegmentationOrder.get_segments` at `Segmentation Export` action. 
New api returns more correct segments.
To use this new api need to merge pull request: 
https://github.com/greenpeace-cee/de.systopia.segmentation/pull/7