### PR TITLE
GP-40144: Exclude  table and columns from logging

### DIFF
--- a/CRM/Sqltasks/Upgrader.php
+++ b/CRM/Sqltasks/Upgrader.php
@@ -157,7 +157,7 @@ class CRM_Sqltasks_Upgrader extends CRM_Sqltasks_Upgrader_Base {
           $scheduled_vars = array('', '', '', '', '');
           break;
       }
-      list($scheduled_month, $scheduled_weekday, $scheduled_day, $scheduled_hour, $scheduled_minute) = $scheduled_vars;
+      [$scheduled_month, $scheduled_weekday, $scheduled_day, $scheduled_hour, $scheduled_minute] = $scheduled_vars;
 
       $config = $task->getConfiguration();
       $config['scheduled_month']   = CRM_Utils_Array::value('scheduled_month',   $config, $scheduled_month);
@@ -446,6 +446,17 @@ class CRM_Sqltasks_Upgrader extends CRM_Sqltasks_Upgrader_Base {
         $this->ctx->log->info('Clear cache to activate new settings.');
         CRM_Core_Invoke::rebuildMenuAndCaches();
         return TRUE;
+    }
+
+    /**
+     * Update logging triggers to apply log exclusions
+     *
+     * @return true
+     */
+    public function upgrade_0310() {
+      $logging = new CRM_Logging_Schema();
+      $logging->fixSchemaDifferences();
+      return TRUE;
     }
 
 }

--- a/sqltasks.php
+++ b/sqltasks.php
@@ -254,3 +254,45 @@ function sqltasks_civicrm_tokenValues(&$values, $cids, $job = NULL, $tokens = ar
     }
   }
 }
+
+/**
+ * Implements hook_alterLogTables().
+ *
+ * @param array $logTableSpec
+ */
+function sqltasks_civicrm_alterLogTables(&$logTableSpec) {
+  if (empty($logTableSpec) && is_array($logTableSpec)) {
+    return;
+  }
+
+  // To apply those setting need turn off and then turn on logging at the setting page(civicrm/admin/setting/misc)
+  // Tt recreates triggers at database and creates log tables if needed.
+  // If exclude table form logs by 'alterLogTables' hook, it doesn't delete log table.
+  // This logic works on CiviCRM 5.51.3.
+  $excludedLogItems = [
+    'tables' => [
+      'civicrm_sqltasks_execution',
+    ],
+    'columns' => [
+      'civicrm_sqltasks' => ['last_execution', 'running_since', 'last_runtime'],
+    ]
+  ];
+
+  foreach ($excludedLogItems['tables'] as $excludedLogTable) {
+    if (isset($logTableSpec[$excludedLogTable])) {
+      unset($logTableSpec[$excludedLogTable]);
+    }
+  }
+
+  foreach ($excludedLogItems['columns'] as $tableName => $columnNames) {
+    if (isset($logTableSpec[$tableName])) {
+      if (isset($logTableSpec[$tableName]['exceptions']) && is_array($logTableSpec[$tableName]['exceptions'])) {
+        foreach ($columnNames as $columnName) {
+          $logTableSpec[$tableName][] = $columnName;
+        }
+      } else {
+        $logTableSpec[$tableName]['exceptions'] = $columnNames;
+      }
+    }
+  }
+}

--- a/sqltasks.php
+++ b/sqltasks.php
@@ -265,9 +265,9 @@ function sqltasks_civicrm_alterLogTables(&$logTableSpec) {
     return;
   }
 
-  // To apply those setting need turn off and then turn on logging at the setting page(civicrm/admin/setting/misc)
-  // Tt recreates triggers at database and creates log tables if needed.
-  // If exclude table form logs by 'alterLogTables' hook, it doesn't delete log table.
+  // To apply those settings need turn off and then turn on logging at the setting page(civicrm/admin/setting/misc)
+  // It recreates triggers at database and creates log tables if needed.
+  // If exclude table form logs by 'alterLogTables' hook, it doesn't delete logs tables.
   // This logic works on CiviCRM 5.51.3.
   $excludedLogItems = [
     'tables' => [


### PR DESCRIPTION
- Exclude from logging:
-- Table: `civicrm_sqltasks_execution` 
--  Columns: `civicrm_sqltasks.last_execution`, `civicrm_sqltasks.running_since`, `civicrm_sqltasks.last_runtime` columns from logging.
- To apply those settings need turn off and then turn on `logging` at the setting page(`civicrm/admin/setting/misc`)
--   It recreates triggers at database and creates log tables if needed.
--   If exclude table form logs by 'alterLogTables' hook, it doesn't delete logs tables.
--   This logic works on CiviCRM 5.51.3.