### PR TITLE
EN-67 Fix task config values not being HTML-decoded

### DIFF
--- a/CRM/Sqltasks/Action.php
+++ b/CRM/Sqltasks/Action.php
@@ -43,6 +43,8 @@ abstract class CRM_Sqltasks_Action {
    */
   public function __construct(CRM_Sqltasks_BAO_SqlTask $task, array $config) {
     $this->task = $task;
+    // undo what CRM_Utils_API_HTMLInputCoder does to the config when it's persisted to DB
+    CRM_Utils_API_HTMLInputCoder::singleton()->decodeOutput($config);
     $this->config = $config;
     $this->has_executed = TRUE;
   }

--- a/CRM/Sqltasks/Action/RunPHP.php
+++ b/CRM/Sqltasks/Action/RunPHP.php
@@ -75,7 +75,7 @@ class CRM_Sqltasks_Action_RunPHP extends CRM_Sqltasks_Action {
     // has_executed is always false for RunSQL
     $this->resetHasExecuted();
     try {
-      eval(html_entity_decode($this->getConfigValue('php_code')));
+      eval($this->getConfigValue('php_code'));
     }
     catch (Exception $e) {
       $this->log("PHP failed: " . $e->getMessage() . " - " . $e->getTraceAsString());

--- a/CRM/Sqltasks/Action/RunSQL.php
+++ b/CRM/Sqltasks/Action/RunSQL.php
@@ -72,7 +72,7 @@ class CRM_Sqltasks_Action_RunSQL extends CRM_Sqltasks_Action {
     $this->resetHasExecuted();
     try {
       // prepare
-      $script = html_entity_decode($this->getConfigValue('script'));
+      $script = $this->getConfigValue('script');
       if (!empty($this->context['input_val'])) {
         $ctx_val = $this->context['input_val'];
 

--- a/CRM/Sqltasks/Action/SegmentationAssign.php
+++ b/CRM/Sqltasks/Action/SegmentationAssign.php
@@ -356,7 +356,7 @@ class CRM_Sqltasks_Action_SegmentationAssign extends CRM_Sqltasks_Action {
     $campaign = civicrm_api3('Campaign', 'getsingle', array(
       'id'     => $campaign_id,
       'return' => 'id,status_id'));
-    if ($campaign['status_id'] == 1) {
+    if ($campaign['status_id'] ?? NULL == 1) {
       return FALSE;
     } else {
       civicrm_api3('Campaign', 'create', array(

--- a/tests/phpunit/CRM/Sqltasks/Action/RunPHPTest.php
+++ b/tests/phpunit/CRM/Sqltasks/Action/RunPHPTest.php
@@ -25,7 +25,8 @@ class CRM_Sqltasks_Action_RunPHPTest extends CRM_Sqltasks_Action_AbstractActionT
         [
           'type'     => 'CRM_Sqltasks_Action_RunPHP',
           'enabled'  => TRUE,
-          'php_code' => "CRM_Core_DAO::executeQuery('TRUNCATE TABLE tmp_test_action_php');"
+          // using &gt; to test HTML-decoding specialness
+          'php_code' => "if (2 &gt; 1) { CRM_Core_DAO::executeQuery('TRUNCATE TABLE tmp_test_action_php'); }"
         ],
       ]
     ];

--- a/tests/phpunit/CRM/Sqltasks/Action/SegmentationAssignTest.php
+++ b/tests/phpunit/CRM/Sqltasks/Action/SegmentationAssignTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Civi\Api4\SegmentationOrder;
+
 /**
  * Test SegmentationAssign Action, requires de.systopia.segmentation
  *
@@ -29,6 +31,20 @@ class CRM_Sqltasks_Action_SegmentationAssignTest extends CRM_Sqltasks_Action_Abs
         'The de.systopia.segmentation extension is not available.'
       );
     }
+    $contacts = [];
+    $rows = [];
+    for ($i = 0; $i < 5; $i++) {
+      $contactID = self::createRandomTestContact();
+      // test segment names with <> to check for HTMLInputCoder issues
+      $segment = $i % 2 ? 'Segment > 1' : 'Segment < 2';
+
+      $contacts[] = [
+        'contact_id' => $contactID,
+        'segment'    => $segment,
+      ];
+
+      $rows[] = 'SELECT ' . $contactID . ' AS contact_id, \'' . $segment . '\' AS segment_name';
+    }
 
     $campaignId = $this->callApiSuccess('Campaign', 'create', array(
       'sequential' => 1,
@@ -43,7 +59,7 @@ class CRM_Sqltasks_Action_SegmentationAssignTest extends CRM_Sqltasks_Action_Abs
           'type'    => 'CRM_Sqltasks_Action_RunSQL',
           'enabled' => TRUE,
           'script'  => "DROP TABLE IF EXISTS tmp_test_action_segmentationassign;
-                        CREATE TABLE tmp_test_action_segmentationassign AS " . self::TEST_CONTACT_SQL,
+                        CREATE TABLE tmp_test_action_segmentationassign AS " . implode(' UNION ', $rows),
         ],
         [
           'type'                => 'CRM_Sqltasks_Action_SegmentationAssign',
@@ -51,9 +67,10 @@ class CRM_Sqltasks_Action_SegmentationAssignTest extends CRM_Sqltasks_Action_Abs
           'table'               => 'tmp_test_action_segmentationassign',
           'campaign_id'         => $campaignId,
           'segment_name'        => 'testSegmentationAssign',
-          'start'               => 'leave',
-          'segment_order'       => '',
+          'start'               => 'restart',
+          'segment_order'       => "Segment &gt; 1\nSegment &lt; 2",
           'segment_order_table' => '',
+          'segment_from_table'  => 1
         ],
         [
           'type'    => 'CRM_Sqltasks_Action_PostSQL',
@@ -65,20 +82,36 @@ class CRM_Sqltasks_Action_SegmentationAssignTest extends CRM_Sqltasks_Action_Abs
 
     $this->createAndExecuteTask([ 'config' => $config ]);
 
-    $this->assertLogContains('Resolved 1 segment(s).', 'Should have resolved one segment');
-    $this->assertLogContains("Assigned 1 new contacts to segment 'testSegmentationAssign'.", 'Should have assigned one contact to segment "testSegmentationAssign"');
+    $this->assertLogContains('Resolved 2 segment(s).', 'Should have resolved two segments');
+    $this->assertLogContains("Assigned 2 new contacts to segment 'Segment > 1'.", 'Should have assigned 2 contact to segment "Segment > 1"');
+    $this->assertLogContains("Assigned 3 new contacts to segment 'Segment < 2'.", 'Should have assigned 3 contact to segment "Segment < 2"');
+    $this->assertLogContains("Campaign 1 has been consolidated and (re)started.", 'Should have restarted campaign');
     $this->assertLogContains("Action 'Assign to Campaign (Segmentation)' executed in", 'Assign to Campaign action should have succeeded');
-    $this->assertEquals(
-      1,
-      CRM_Core_DAO::singleValueQuery(
-        "SELECT COUNT(*) FROM civicrm_segmentation WHERE campaign_id = %0 AND entity_id = %1",
-        [
-          [$campaignId, 'Integer'],
-          [$this->contactId, 'Integer'],
-        ]
-      ),
-      'Should have added contact to segment'
+    $segmentationOrders = SegmentationOrder::get(FALSE)
+      ->addSelect('segment_id', 'order_number', 'segment_id.name')
+      ->addWhere('campaign_id', '=', $campaignId)
+      ->execute()
+      ->indexBy('segment_id.name');
+    $this->assertEquals(1, $segmentationOrders['Segment > 1']['order_number'], 'Segment > 1 should be order_number=1');
+    $this->assertEquals(2, $segmentationOrders['Segment < 2']['order_number'], 'Segment < 2 should be order_number=2');
+    $query = CRM_Core_DAO::executeQuery(
+      "SELECT s.entity_id, si.name
+        FROM civicrm_segmentation s
+        JOIN civicrm_segmentation_index si ON si.id = s.segment_id
+        WHERE campaign_id = %0
+        ORDER BY entity_id",
+      [
+        [$campaignId, 'Integer'],
+      ]
     );
+    $resultContacts = [];
+    while ($query->fetch()) {
+      $resultContacts[] = [
+        'contact_id' => $query->entity_id,
+        'segment'    => $query->name,
+      ];
+    }
+    $this->assertEquals($contacts, $resultContacts, 'Contacts should have been assigned to the correct segments');
   }
 
 }


### PR DESCRIPTION
This applies a more generalistic fix for issues caused by Civi's special `HTMLInputCoder` logic that causes `>` and `<` to be stored as `&gt;` and `&lt;` in the database. Prior to this, we applied decoding in two specific places that commonly use these characters (SQL and PHP scripts). This changes the approach to always decode all config properties.